### PR TITLE
Test/categoryproduct

### DIFF
--- a/client/src/pages/CategoryProduct.js
+++ b/client/src/pages/CategoryProduct.js
@@ -31,7 +31,11 @@ const CategoryProduct = () => {
       const { data } = await axios.get(
         `/api/v1/product/product-category-count/${categorySlug}`
       );
-      if (data?.success) setTotal(data.total ?? 0);
+      if (data?.success) {
+        setTotal(data.total ?? 0);
+      } else {
+        throw new Error("Failed to load total products");
+      }
     } catch (error) {
       console.error(error);
       toast.error("Failed to load total products");
@@ -40,17 +44,16 @@ const CategoryProduct = () => {
 
   // fetch products by category and page
   const fetchProductsByCategory = useCallback(
-    async (pageToLoad, providedSlug) => {
-      const targetSlug = providedSlug ?? slug;
-      if (!targetSlug) return;
-
+    async (pageToLoad) => {
       try {
         setLoading(true);
         const { data } = await axios.get(
-          `/api/v1/product/product-category/${targetSlug}?page=${pageToLoad}&limit=${PAGE_SIZE}`
+          `/api/v1/product/product-category/${slug}?page=${pageToLoad}&limit=${PAGE_SIZE}`
         );
 
-        if (!data?.success) return;
+        if (!data?.success) {
+          throw new Error("Failed to load products");
+        }
 
         if (data.category) setCategory(data.category);
 
@@ -82,9 +85,9 @@ const CategoryProduct = () => {
 
   // on page change (except first page), fetch next page
   useEffect(() => {
-    if (page === 1 || !slug) return;
-    fetchProductsByCategory(page, slug);
-  }, [page, slug, fetchProductsByCategory]);
+    if (page === 1) return;
+    fetchProductsByCategory(page);
+  }, [page, fetchProductsByCategory]);
 
   return (
     <Layout>

--- a/client/src/pages/CategoryProduct.js
+++ b/client/src/pages/CategoryProduct.js
@@ -146,6 +146,7 @@ const CategoryProduct = () => {
               {products && products.length < total && (
                 <button
                   className="btn btn-warning"
+                  disabled={loading}
                   onClick={(e) => {
                     e.preventDefault();
                     setPage((prev) => prev + 1);

--- a/client/src/pages/CategoryProduct.js
+++ b/client/src/pages/CategoryProduct.js
@@ -98,7 +98,7 @@ const CategoryProduct = () => {
         </h6>
         <div className="row">
           <div className="col-md-9 mx-auto">
-            <div className="d-flex flex-wrap justify-content-center">
+            <div className="d-flex flex-wrap justify-content-md-start justify-content-center">
               {products?.map((p) => (
                 <div className="card m-2" key={p._id}>
                   <img

--- a/client/src/pages/CategoryProduct.js
+++ b/client/src/pages/CategoryProduct.js
@@ -52,7 +52,6 @@ const CategoryProduct = () => {
         const { data } = await axios.get(
           `/api/v1/product/product-category/${targetSlug}?page=${pageToLoad}&limit=${PAGE_SIZE}`
         );
-        setLoading(false);
         if (!data?.success) return;
 
         if (data.category) {
@@ -66,9 +65,10 @@ const CategoryProduct = () => {
             : [...prev, ...nextProducts]
         );
       } catch (error) {
-        setLoading(false);
-        console.log(error);
+        console.error(error);
         toast.error("Failed to load products");
+      } finally {
+        setLoading(false);
       }
     },
     [params?.slug]

--- a/client/src/pages/CategoryProduct.js
+++ b/client/src/pages/CategoryProduct.js
@@ -115,7 +115,9 @@ const CategoryProduct = () => {
                       </h5>
                     </div>
                     <p className="card-text ">
-                      {p.description?.substring(0, 60)}...
+                      {p.description.length <= 60
+                        ? p.description
+                        : p.description.substring(0, 60) + "..."}
                     </p>
                     <div className="card-name-price">
                       <button

--- a/client/src/pages/CategoryProduct.js
+++ b/client/src/pages/CategoryProduct.js
@@ -152,7 +152,13 @@ const CategoryProduct = () => {
                     setPage((prev) => prev + 1);
                   }}
                 >
-                  {loading ? "Loading ..." : "Load more"} <AiOutlineReload />
+                  {loading ? (
+                    "Loading ..."
+                  ) : (
+                    <>
+                      Load more <AiOutlineReload />
+                    </>
+                  )}
                 </button>
               )}
             </div>

--- a/client/src/pages/CategoryProduct.js
+++ b/client/src/pages/CategoryProduct.js
@@ -26,24 +26,24 @@ const CategoryProduct = () => {
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(false);
 
+  // fetch total products in category
   const fetchCategoryTotal = useCallback(async (slug) => {
     try {
       const { data } = await axios.get(
         `/api/v1/product/product-category-count/${slug}`
       );
-      if (!data?.success) return;
-      setTotal(data.total ?? 0);
-      if (data.category) {
-        setCategory(data.category);
+      if (data?.success) {
+        setTotal(data.total ?? 0);
       }
     } catch (error) {
       console.error(error);
-      toast.error("Failed to load category details");
+      toast.error("Failed to load total products");
     }
   }, []);
 
+  // fetch products by category and page
   const fetchProductsByCategory = useCallback(
-    async (pageToLoad, slug = params?.slug, append = false) => {
+    async (pageToLoad, slug = params?.slug) => {
       const targetSlug = slug ?? params?.slug;
       if (!targetSlug) return;
 
@@ -52,17 +52,17 @@ const CategoryProduct = () => {
         const { data } = await axios.get(
           `/api/v1/product/product-category/${targetSlug}?page=${pageToLoad}&limit=${PAGE_SIZE}`
         );
+
         if (!data?.success) return;
 
         if (data.category) {
-          setCategory((prev) => prev ?? data.category);
+          setCategory(data.category);
         }
 
         const nextProducts = Array.isArray(data?.products) ? data.products : [];
+
         setProducts((prev) =>
-          pageToLoad === 1 || !append
-            ? nextProducts
-            : [...prev, ...nextProducts]
+          pageToLoad === 1 ? nextProducts : [...prev, ...nextProducts]
         );
       } catch (error) {
         console.error(error);
@@ -74,6 +74,7 @@ const CategoryProduct = () => {
     [params?.slug]
   );
 
+  // on slug change, reset state and fetch first page
   useEffect(() => {
     if (!params?.slug) return;
     setProducts([]);
@@ -84,9 +85,10 @@ const CategoryProduct = () => {
     fetchProductsByCategory(1, params.slug);
   }, [params?.slug, fetchCategoryTotal, fetchProductsByCategory]);
 
+  // on page change (except first page), fetch next page
   useEffect(() => {
     if (page === 1 || !params?.slug) return;
-    fetchProductsByCategory(page, params.slug, true);
+    fetchProductsByCategory(page, params.slug);
   }, [page, params?.slug, fetchProductsByCategory]);
 
   return (

--- a/client/src/pages/CategoryProduct.js
+++ b/client/src/pages/CategoryProduct.js
@@ -1,56 +1,121 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import Layout from "../components/Layout";
 import { useParams, useNavigate } from "react-router-dom";
 import "../styles/CategoryProductStyles.css";
 import axios from "axios";
+import { useCart } from "../context/cart";
+import toast from "react-hot-toast";
+import {
+  formatPrice,
+  getImageUrl,
+  addToCart,
+  handleImgError,
+} from "../utils/productUtils";
+import { AiOutlineReload } from "react-icons/ai";
+
+const PAGE_SIZE = 6;
+
 const CategoryProduct = () => {
   const params = useParams();
+  const [cart, setCart] = useCart();
+
   const navigate = useNavigate();
   const [products, setProducts] = useState([]);
-  const [category, setCategory] = useState([]);
+  const [category, setCategory] = useState(null);
+  const [page, setPage] = useState(1);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(false);
 
-  useEffect(() => {
-    if (params?.slug) getPrductsByCat();
-  }, [params?.slug]);
-  const getPrductsByCat = async () => {
+  const fetchCategoryTotal = useCallback(async (slug) => {
     try {
       const { data } = await axios.get(
-        `/api/v1/product/product-category/${params.slug}`
+        `/api/v1/product/product-category-count/${slug}`
       );
-      setProducts(data?.products);
-      setCategory(data?.category);
+      if (!data?.success) return;
+      setTotal(data.total ?? 0);
+      if (data.category) {
+        setCategory(data.category);
+      }
     } catch (error) {
-      console.log(error);
+      console.error(error);
+      toast.error("Failed to load category details");
     }
-  };
+  }, []);
+
+  const fetchProductsByCategory = useCallback(
+    async (pageToLoad, slug = params?.slug, append = false) => {
+      const targetSlug = slug ?? params?.slug;
+      if (!targetSlug) return;
+
+      try {
+        setLoading(true);
+        const { data } = await axios.get(
+          `/api/v1/product/product-category/${targetSlug}?page=${pageToLoad}&limit=${PAGE_SIZE}`
+        );
+        setLoading(false);
+        if (!data?.success) return;
+
+        if (data.category) {
+          setCategory((prev) => prev ?? data.category);
+        }
+
+        const nextProducts = Array.isArray(data?.products) ? data.products : [];
+        setProducts((prev) =>
+          pageToLoad === 1 || !append
+            ? nextProducts
+            : [...prev, ...nextProducts]
+        );
+      } catch (error) {
+        setLoading(false);
+        console.log(error);
+        toast.error("Failed to load products");
+      }
+    },
+    [params?.slug]
+  );
+
+  useEffect(() => {
+    if (!params?.slug) return;
+    setProducts([]);
+    setCategory(null);
+    setTotal(0);
+    setPage(1);
+    fetchCategoryTotal(params.slug);
+    fetchProductsByCategory(1, params.slug);
+  }, [params?.slug, fetchCategoryTotal, fetchProductsByCategory]);
+
+  useEffect(() => {
+    if (page === 1 || !params?.slug) return;
+    fetchProductsByCategory(page, params.slug, true);
+  }, [page, params?.slug, fetchProductsByCategory]);
 
   return (
     <Layout>
       <div className="container mt-3 category">
-        <h4 className="text-center">Category - {category?.name}</h4>
-        <h6 className="text-center">{products?.length} result found </h6>
+        <h4 className="text-center">Category - {category?.name ?? ""}</h4>
+        <h6 className="text-center">
+          {total} result{total === 1 ? "" : "s"} found{" "}
+        </h6>
         <div className="row">
-          <div className="col-md-9 offset-1">
-            <div className="d-flex flex-wrap">
+          <div className="col-md-9 mx-auto">
+            <div className="d-flex flex-wrap justify-content-center">
               {products?.map((p) => (
                 <div className="card m-2" key={p._id}>
                   <img
-                    src={`/api/v1/product/product-photo/${p._id}`}
+                    src={getImageUrl(p._id)}
                     className="card-img-top"
                     alt={p.name}
+                    onError={handleImgError}
                   />
                   <div className="card-body">
                     <div className="card-name-price">
                       <h5 className="card-title">{p.name}</h5>
                       <h5 className="card-title card-price">
-                        {p.price.toLocaleString("en-US", {
-                          style: "currency",
-                          currency: "USD",
-                        })}
+                        {formatPrice(p.price)}
                       </h5>
                     </div>
                     <p className="card-text ">
-                      {p.description.substring(0, 60)}...
+                      {p.description?.substring(0, 60)}...
                     </p>
                     <div className="card-name-price">
                       <button
@@ -59,37 +124,35 @@ const CategoryProduct = () => {
                       >
                         More Details
                       </button>
-                      {/* <button
-                    className="btn btn-dark ms-1"
-                    onClick={() => {
-                      setCart([...cart, p]);
-                      localStorage.setItem(
-                        "cart",
-                        JSON.stringify([...cart, p])
-                      );
-                      toast.success("Item Added to cart");
-                    }}
-                  >
-                    ADD TO CART
-                  </button> */}
+                      <button
+                        className="btn btn-dark ms-1"
+                        onClick={() => addToCart(cart, setCart, p)}
+                      >
+                        ADD TO CART
+                      </button>
                     </div>
                   </div>
                 </div>
               ))}
+              {!loading && products?.length === 0 && (
+                <p className="text-center w-100">
+                  No products found in this category.
+                </p>
+              )}
             </div>
-            {/* <div className="m-2 p-3">
-            {products && products.length < total && (
-              <button
-                className="btn btn-warning"
-                onClick={(e) => {
-                  e.preventDefault();
-                  setPage(page + 1);
-                }}
-              >
-                {loading ? "Loading ..." : "Loadmore"}
-              </button>
-            )}
-          </div> */}
+            <div className="m-2 p-3">
+              {products && products.length < total && (
+                <button
+                  className="btn btn-warning"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    setPage((prev) => prev + 1);
+                  }}
+                >
+                  {loading ? "Loading ..." : "Load more"} <AiOutlineReload />
+                </button>
+              )}
+            </div>
           </div>
         </div>
       </div>

--- a/client/src/pages/CategoryProduct.js
+++ b/client/src/pages/CategoryProduct.js
@@ -26,6 +26,7 @@ const CategoryProduct = () => {
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(false);
 
+  // fetch total product count for given category
   const fetchCategoryTotal = useCallback(async (categorySlug) => {
     try {
       const { data } = await axios.get(

--- a/client/src/pages/CategoryProduct.test.js
+++ b/client/src/pages/CategoryProduct.test.js
@@ -1,11 +1,11 @@
-// CategoryProduct.test.jsx
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import axios from "axios";
 import CategoryProduct from "./CategoryProduct";
 import { useParams, useNavigate } from "react-router-dom";
 import { useCart } from "../context/cart";
+import { addToCart } from "../utils/prodctUtils";
 
 jest.mock("axios");
 
@@ -300,5 +300,27 @@ describe("CategoryProduct", () => {
     expect(
       screen.getByRole("button", { name: /Load more/i })
     ).toBeInTheDocument();
+  });
+
+  describe("Interactions", () => {
+    it("navigates to product details on 'More Details'", async () => {
+      const p = makeProduct({ name: "GoDetails", slug: "go-details" });
+
+      axios.get
+        .mockResolvedValueOnce({ data: { success: true, total: 1 } })
+        .mockResolvedValueOnce({
+          data: {
+            success: true,
+            category: { name: CATEGORY_SHIRTS },
+            products: [p],
+          },
+        });
+
+      renderWithRouter(<CategoryProduct />);
+
+      expect(await screen.findByText(p.name)).toBeInTheDocument();
+      fireEvent.click(screen.getByRole("button", { name: /More Details/i }));
+      expect(navigate).toHaveBeenCalledWith(`/product/${p.slug}`);
+    });
   });
 });

--- a/client/src/pages/CategoryProduct.test.js
+++ b/client/src/pages/CategoryProduct.test.js
@@ -272,6 +272,22 @@ describe("CategoryProduct", () => {
       expect(await screen.findByText("P3")).toBeInTheDocument();
       expect(screen.queryByRole("button", { name: /Load more/i })).toBeNull();
     });
+
+    it("uses 0 as total when count succeeds but total is missing", async () => {
+      axios.get
+        .mockResolvedValueOnce({ data: { success: true } }) // no total field
+        .mockResolvedValueOnce({
+          data: {
+            success: true,
+            category: { name: CATEGORY_SHIRTS },
+            products: [],
+          },
+        });
+
+      renderWithRouter(<CategoryProduct />);
+
+      expect(await screen.findByText(/0 results found/i)).toBeInTheDocument();
+    });
   });
 
   it("shows Load more button when not all items are loaded", async () => {

--- a/client/src/pages/CategoryProduct.test.js
+++ b/client/src/pages/CategoryProduct.test.js
@@ -288,6 +288,24 @@ describe("CategoryProduct", () => {
 
       expect(await screen.findByText(/0 results found/i)).toBeInTheDocument();
     });
+
+    it("handles non-array products payload gracefully", async () => {
+      axios.get
+        .mockResolvedValueOnce({ data: { success: true, total: 0 } })
+        .mockResolvedValueOnce({
+          data: {
+            success: true,
+            category: { name: CATEGORY_SHIRTS },
+            products: null, // not an array
+          },
+        });
+
+      renderWithRouter(<CategoryProduct />);
+
+      expect(
+        await screen.findByText(/No products found in this category/i)
+      ).toBeInTheDocument();
+    });
   });
 
   it("shows Load more button when not all items are loaded", async () => {

--- a/client/src/pages/CategoryProduct.test.js
+++ b/client/src/pages/CategoryProduct.test.js
@@ -159,5 +159,13 @@ describe("CategoryProduct", () => {
       expect(screen.getByText(pantsPage1[0].name)).toBeInTheDocument();
       expect(screen.queryByText(shirtsPage1[0].name)).toBeNull();
     });
+
+    it("does not fetch when slug is missing", async () => {
+      useParams.mockReturnValueOnce({ slug: undefined });
+
+      renderWithRouter(<CategoryProduct />, ["/category/"]);
+
+      await waitFor(() => expect(axios.get).not.toHaveBeenCalled());
+    });
   });
 });

--- a/client/src/pages/CategoryProduct.test.js
+++ b/client/src/pages/CategoryProduct.test.js
@@ -448,5 +448,38 @@ describe("CategoryProduct", () => {
         screen.getByRole("button", { name: /Load more/i })
       ).toBeInTheDocument(); // button still there to retry
     });
+
+    it("shows error toast with success=false in products response", async () => {
+      axios.get
+        .mockResolvedValueOnce({ data: { success: true, total: 3 } })
+        .mockResolvedValueOnce({ data: { success: false } });
+      renderWithRouter(<CategoryProduct />);
+      await waitFor(() =>
+        expect(toast.error).toHaveBeenCalledWith("Failed to load products")
+      );
+      expect(
+        screen.getByText(/No products found in this category/i)
+      ).toBeInTheDocument();
+    });
+
+    it("shows error toast with success=false in total products response", async () => {
+      axios.get
+        .mockResolvedValueOnce({ data: { success: false } })
+        .mockResolvedValueOnce({
+          data: {
+            success: true,
+            category: { name: CATEGORY_SHIRTS },
+            products: [],
+          },
+        });
+
+      renderWithRouter(<CategoryProduct />);
+
+      await waitFor(() =>
+        expect(toast.error).toHaveBeenCalledWith(
+          "Failed to load total products"
+        )
+      );
+    });
   });
 });

--- a/client/src/pages/CategoryProduct.test.js
+++ b/client/src/pages/CategoryProduct.test.js
@@ -45,3 +45,20 @@ const CATEGORY_PANTS = "Pants";
 
 const ROUTE_SHIRTS = `/category/${SLUG_SHIRTS}`;
 const ROUTE_PANTS = `/category/${SLUG_PANTS}`;
+
+const API_COUNT = (slug) => `/api/v1/product/product-category-count/${slug}`;
+const API_PAGE = (slug, page, limit = 6) =>
+  `/api/v1/product/product-category/${slug}?page=${page}&limit=${limit}`;
+
+const renderWithRouter = (ui, initialEntries = [ROUTE_SHIRTS]) =>
+  render(<MemoryRouter initialEntries={initialEntries}>{ui}</MemoryRouter>);
+
+const makeProduct = (overrides = {}) => ({
+  _id: overrides._id ?? "p1",
+  name: overrides.name ?? "Blue Tee",
+  price: overrides.price ?? 100,
+  slug: overrides.slug ?? "blue-tee",
+  description: overrides.description ?? "A comfy tee",
+  ...overrides,
+});
+

--- a/client/src/pages/CategoryProduct.test.js
+++ b/client/src/pages/CategoryProduct.test.js
@@ -168,4 +168,39 @@ describe("CategoryProduct", () => {
       await waitFor(() => expect(axios.get).not.toHaveBeenCalled());
     });
   });
+
+  describe("Rendering & content", () => {
+    it("shows pluralized results count", async () => {
+      axios.get
+        .mockResolvedValueOnce({ data: { success: true, total: 2 } })
+        .mockResolvedValueOnce({
+          data: {
+            success: true,
+            category: { name: CATEGORY_SHIRTS },
+            products: [
+              makeProduct({ name: "First" }),
+              makeProduct({ _id: "p2", name: "Second" }),
+            ],
+          },
+        });
+
+      renderWithRouter(<CategoryProduct />);
+      expect(await screen.findByText(/2 results found/i)).toBeInTheDocument(); // plural "results"
+    });
+
+    it("shows singular result count", async () => {
+      axios.get
+        .mockResolvedValueOnce({ data: { success: true, total: 1 } })
+        .mockResolvedValueOnce({
+          data: {
+            success: true,
+            category: { name: CATEGORY_SHIRTS },
+            products: [makeProduct({ name: "Solo" })],
+          },
+        });
+
+      renderWithRouter(<CategoryProduct />);
+      expect(await screen.findByText(/1 result found/i)).toBeInTheDocument(); // singular "result"
+    });
+  });
 });

--- a/client/src/pages/CategoryProduct.test.js
+++ b/client/src/pages/CategoryProduct.test.js
@@ -202,5 +202,34 @@ describe("CategoryProduct", () => {
       renderWithRouter(<CategoryProduct />);
       expect(await screen.findByText(/1 result found/i)).toBeInTheDocument(); // singular "result"
     });
+
+    it("renders description truncated and fallback when missing", async () => {
+      const longDesc =
+        "This is a very long description that should be truncated at sixty characters to keep the card compact.";
+      const products = [
+        makeProduct({ name: "LongDesc", description: longDesc }),
+        makeProduct({ _id: "p2", name: "NoDesc", description: undefined }),
+      ]; // one with long desc, one without
+    
+      axios.get
+        .mockResolvedValueOnce({ data: { success: true, total: 2 } })
+        .mockResolvedValueOnce({
+          data: {
+            success: true,
+            category: { name: CATEGORY_SHIRTS },
+            products,
+          },
+        });
+
+      renderWithRouter(<CategoryProduct />);
+
+      expect(
+        await screen.findByText(`Category - ${CATEGORY_SHIRTS}`)
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/This is a very long description/)
+      ).toBeInTheDocument();
+      expect(screen.getByText(/No description available/)).toBeInTheDocument();
+    });
   });
 });

--- a/client/src/pages/CategoryProduct.test.js
+++ b/client/src/pages/CategoryProduct.test.js
@@ -210,7 +210,7 @@ describe("CategoryProduct", () => {
         makeProduct({ name: "LongDesc", description: longDesc }),
         makeProduct({ _id: "p2", name: "NoDesc", description: undefined }),
       ]; // one with long desc, one without
-    
+
       axios.get
         .mockResolvedValueOnce({ data: { success: true, total: 2 } })
         .mockResolvedValueOnce({
@@ -230,6 +230,27 @@ describe("CategoryProduct", () => {
         screen.getByText(/This is a very long description/)
       ).toBeInTheDocument();
       expect(screen.getByText(/No description available/)).toBeInTheDocument();
+    });
+
+    it("shows empty state when no products and total=0", async () => {
+      axios.get
+        .mockResolvedValueOnce({ data: { success: true, total: 0 } })
+        .mockResolvedValueOnce({
+          data: {
+            success: true,
+            category: { name: CATEGORY_SHIRTS },
+            products: [],
+          },
+        });
+
+      renderWithRouter(<CategoryProduct />);
+
+      expect(
+        await screen.findByText(/No products found in this category/i)
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /Load more/i })
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/client/src/pages/CategoryProduct.test.js
+++ b/client/src/pages/CategoryProduct.test.js
@@ -6,6 +6,7 @@ import CategoryProduct from "./CategoryProduct";
 import { useParams, useNavigate } from "react-router-dom";
 import { useCart } from "../context/cart";
 import { addToCart } from "../utils/productUtils";
+import { toast } from "react-hot-toast";
 
 jest.mock("axios");
 
@@ -26,10 +27,7 @@ jest.mock("../context/cart", () => ({
   useCart: jest.fn(),
 }));
 
-jest.mock("react-hot-toast", () => ({
-  error: jest.fn(),
-  success: jest.fn(),
-}));
+jest.mock("react-hot-toast");
 
 jest.mock("../utils/productUtils", () => ({
   formatPrice: (n) => `$${Number(n).toFixed(2)}`,
@@ -383,6 +381,18 @@ describe("CategoryProduct", () => {
         ).toBeInTheDocument();
       });
       expect(screen.queryByRole("button", { name: /Load more/i })).toBeNull();
+    });
+  });
+
+  describe("Error states", () => {
+    it("shows error toast when count fetch fails", async () => {
+      axios.get.mockRejectedValueOnce(new Error("Network error"));
+      renderWithRouter(<CategoryProduct />);
+      await waitFor(() =>
+        expect(toast.error).toHaveBeenCalledWith(
+          "Failed to load total products"
+        )
+      );
     });
   });
 });

--- a/client/src/pages/CategoryProduct.test.js
+++ b/client/src/pages/CategoryProduct.test.js
@@ -5,7 +5,7 @@ import axios from "axios";
 import CategoryProduct from "./CategoryProduct";
 import { useParams, useNavigate } from "react-router-dom";
 import { useCart } from "../context/cart";
-import { addToCart } from "../utils/prodctUtils";
+import { addToCart } from "../utils/productUtils";
 
 jest.mock("axios");
 
@@ -321,6 +321,28 @@ describe("CategoryProduct", () => {
       expect(await screen.findByText(p.name)).toBeInTheDocument();
       fireEvent.click(screen.getByRole("button", { name: /More Details/i }));
       expect(navigate).toHaveBeenCalledWith(`/product/${p.slug}`);
+    });
+
+    it("calls addToCart on 'ADD TO CART'", async () => {
+      const p = makeProduct({ _id: "123", name: "CartItem" });
+
+      axios.get
+        .mockResolvedValueOnce({ data: { success: true, total: 1 } })
+        .mockResolvedValueOnce({
+          data: {
+            success: true,
+            category: { name: CATEGORY_SHIRTS },
+            products: [p],
+          },
+        });
+
+      renderWithRouter(<CategoryProduct />);
+
+      expect(await screen.findByText(p.name)).toBeInTheDocument();
+      fireEvent.click(screen.getByRole("button", { name: /ADD TO CART/i }));
+      expect(addToCart).toHaveBeenCalledTimes(1);
+      const call = addToCart.mock.calls[0];
+      expect(call[2]).toMatchObject({ _id: "123", name: "CartItem" }); // make sure correct product passed as argument
     });
   });
 });

--- a/client/src/pages/CategoryProduct.test.js
+++ b/client/src/pages/CategoryProduct.test.js
@@ -37,3 +37,11 @@ jest.mock("../utils/productUtils", () => ({
   addToCart: jest.fn(),
   handleImgError: jest.fn(),
 }));
+
+const SLUG_SHIRTS = "shirts";
+const SLUG_PANTS = "pants";
+const CATEGORY_SHIRTS = "Shirts";
+const CATEGORY_PANTS = "Pants";
+
+const ROUTE_SHIRTS = `/category/${SLUG_SHIRTS}`;
+const ROUTE_PANTS = `/category/${SLUG_PANTS}`;

--- a/client/src/pages/CategoryProduct.test.js
+++ b/client/src/pages/CategoryProduct.test.js
@@ -394,5 +394,20 @@ describe("CategoryProduct", () => {
         )
       );
     });
+
+    it("shows error toast when products fetch fails (page 1) and shows empty state", async () => {
+      axios.get
+        .mockResolvedValueOnce({ data: { success: true, total: 3 } })
+        .mockRejectedValueOnce(new Error("Network error"));
+
+      renderWithRouter(<CategoryProduct />);
+
+      await waitFor(() =>
+        expect(toast.error).toHaveBeenCalledWith("Failed to load products")
+      );
+      expect(
+        screen.getByText(/No products found in this category/i)
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/client/src/pages/CategoryProduct.test.js
+++ b/client/src/pages/CategoryProduct.test.js
@@ -306,32 +306,34 @@ describe("CategoryProduct", () => {
         await screen.findByText(/No products found in this category/i)
       ).toBeInTheDocument();
     });
-  });
 
-  it("shows Load more button when not all items are loaded", async () => {
-    // total 10 products but only 6 returned on page 1, so more to load
-    const totalProducts = 10;
-    const page1 = Array.from({ length: 6 }).map((_, i) =>
-      makeProduct({ _id: `p${i + 1}`, name: `P${i + 1}` })
-    );
+    it("shows Load more button when not all items are loaded", async () => {
+      // total 10 products but only 6 returned on page 1, so more to load
+      const totalProducts = 10;
+      const page1 = Array.from({ length: 6 }).map((_, i) =>
+        makeProduct({ _id: `p${i + 1}`, name: `P${i + 1}` })
+      );
 
-    axios.get
-      .mockResolvedValueOnce({ data: { success: true, total: totalProducts } })
-      .mockResolvedValueOnce({
-        data: {
-          success: true,
-          category: { name: CATEGORY_SHIRTS },
-          products: page1,
-        },
-      });
-    renderWithRouter(<CategoryProduct />);
+      axios.get
+        .mockResolvedValueOnce({
+          data: { success: true, total: totalProducts },
+        })
+        .mockResolvedValueOnce({
+          data: {
+            success: true,
+            category: { name: CATEGORY_SHIRTS },
+            products: page1,
+          },
+        });
+      renderWithRouter(<CategoryProduct />);
 
-    expect(
-      await screen.findByText(page1[page1.length - 1].name)
-    ).toBeInTheDocument(); // wait for last product to confirm load
-    expect(
-      screen.getByRole("button", { name: /Load more/i })
-    ).toBeInTheDocument();
+      expect(
+        await screen.findByText(page1[page1.length - 1].name)
+      ).toBeInTheDocument(); // wait for last product to confirm load
+      expect(
+        screen.getByRole("button", { name: /Load more/i })
+      ).toBeInTheDocument();
+    });
   });
 
   describe("Interactions", () => {

--- a/client/src/pages/CategoryProduct.test.js
+++ b/client/src/pages/CategoryProduct.test.js
@@ -1,0 +1,39 @@
+// CategoryProduct.test.jsx
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import axios from "axios";
+import CategoryProduct from "./CategoryProduct";
+import { useParams, useNavigate } from "react-router-dom";
+import { useCart } from "../context/cart";
+
+jest.mock("axios");
+
+jest.mock("../components/Layout", () => {
+  return ({ children }) => <div data-testid="layout">{children}</div>;
+});
+
+jest.mock("react-router-dom", () => {
+  const actual = jest.requireActual("react-router-dom");
+  return {
+    ...actual,
+    useParams: jest.fn(),
+    useNavigate: jest.fn(),
+  };
+});
+
+jest.mock("../context/cart", () => ({
+  useCart: jest.fn(),
+}));
+
+jest.mock("react-hot-toast", () => ({
+  error: jest.fn(),
+  success: jest.fn(),
+}));
+
+jest.mock("../utils/productUtils", () => ({
+  formatPrice: (n) => `$${Number(n).toFixed(2)}`,
+  getImageUrl: (id) => `/img/${id}`,
+  addToCart: jest.fn(),
+  handleImgError: jest.fn(),
+}));

--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -347,6 +347,32 @@ export const productCategoryController = async (req, res) => {
   }
 };
 
+export const productCategoryCountController = async (req, res) => {
+  try {
+    const category = await categoryModel.findOne({ slug: req.params.slug });
+    if (!category) {
+      return res.status(404).send({
+        success: false,
+        message: "Category not found",
+      });
+    }
+
+    const total = await productModel.countDocuments({ category: category._id });
+    res.status(200).send({
+      success: true,
+      total,
+      category,
+    });
+  } catch (error) {
+    console.log(error);
+    res.status(400).send({
+      success: false,
+      error,
+      message: "Error While Getting products count",
+    });
+  }
+};
+
 //payment gateway api
 //token
 export const braintreeTokenController = async (req, res) => {

--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -8,10 +8,11 @@ import braintree from "braintree";
 import dotenv from "dotenv";
 
 const DEFAULT_PAGE_SIZE = 6;
+const DEFAULT_PAGE_NUMBER = 1;
 
 dotenv.config();
 
-//payment gateway
+// payment gateway
 var gateway = new braintree.BraintreeGateway({
   environment: braintree.Environment.Sandbox,
   merchantId: process.env.BRAINTREE_MERCHANT_ID,
@@ -24,7 +25,7 @@ export const createProductController = async (req, res) => {
     const { name, description, price, category, quantity, shipping } =
       req.fields;
     const { photo } = req.files;
-    //alidation
+    // validation
     switch (true) {
       case !name:
         return res.status(500).send({ error: "Name is Required" });
@@ -63,7 +64,7 @@ export const createProductController = async (req, res) => {
   }
 };
 
-//get all products
+// get all products
 export const getProductController = async (req, res) => {
   try {
     const products = await productModel
@@ -128,7 +129,7 @@ export const productPhotoController = async (req, res) => {
   }
 };
 
-//delete controller
+// delete controller
 export const deleteProductController = async (req, res) => {
   try {
     await productModel.findByIdAndDelete(req.params.pid).select("-photo");
@@ -146,13 +147,13 @@ export const deleteProductController = async (req, res) => {
   }
 };
 
-//upate producta
+// update products
 export const updateProductController = async (req, res) => {
   try {
     const { name, description, price, category, quantity, shipping } =
       req.fields;
     const { photo } = req.files;
-    //alidation
+    // validation
     switch (true) {
       case !name:
         return res.status(500).send({ error: "Name is Required" });
@@ -238,7 +239,7 @@ export const productCountController = async (req, res) => {
 // product list based on page
 export const productListController = async (req, res) => {
   try {
-    const page = req.params.page ? req.params.page : 1;
+    const page = req.params.page ? req.params.page : DEFAULT_PAGE_NUMBER;
     const products = await productModel
       .find({})
       .select("-photo")
@@ -319,7 +320,7 @@ export const productCategoryController = async (req, res) => {
       });
     }
 
-    const page = parseInt(req.query.page, 10) || 1;
+    const page = parseInt(req.query.page, 10) || DEFAULT_PAGE_NUMBER;
     const limit = parseInt(req.query.limit, 10) || DEFAULT_PAGE_SIZE;
 
     const products = await productModel
@@ -342,11 +343,12 @@ export const productCategoryController = async (req, res) => {
     res.status(400).send({
       success: false,
       error,
-      message: "Error While Getting products",
+      message: "Error while getting products",
     });
   }
 };
 
+// get total products by category
 export const productCategoryCountController = async (req, res) => {
   try {
     const category = await categoryModel.findOne({ slug: req.params.slug });
@@ -368,13 +370,13 @@ export const productCategoryCountController = async (req, res) => {
     res.status(400).send({
       success: false,
       error,
-      message: "Error While Getting products count",
+      message: "Error while getting products count",
     });
   }
 };
 
-//payment gateway api
-//token
+// payment gateway api
+// token
 export const braintreeTokenController = async (req, res) => {
   try {
     gateway.clientToken.generate({}, function (err, response) {
@@ -389,7 +391,7 @@ export const braintreeTokenController = async (req, res) => {
   }
 };
 
-//payment
+// payment
 export const brainTreePaymentController = async (req, res) => {
   try {
     const { nonce, cart } = req.body;

--- a/routes/productRoutes.js
+++ b/routes/productRoutes.js
@@ -7,6 +7,7 @@ import {
   getProductController,
   getSingleProductController,
   productCategoryController,
+  productCategoryCountController,
   productCountController,
   productFiltersController,
   productListController,
@@ -66,6 +67,12 @@ router.get("/related-product/:pid/:cid", realtedProductController);
 
 //category wise product
 router.get("/product-category/:slug", productCategoryController);
+
+//category wise product count
+router.get(
+  "/product-category-count/:slug",
+  productCategoryCountController
+);
 
 //payments routes
 //token


### PR DESCRIPTION
## Outline
This PR introduces unit testing for CategoryProduct.js, the relevant fixes to the component, and a new endpoint to fetch the total number of products for a given category. CategoryProduct.js now supports pagination

### Component under test + final result

https://github.com/user-attachments/assets/e99e1517-c7d2-4b33-b339-9f19ea3d0850

### Key changes
- routes/productRoutes.js
  - new endpoint `/product-category-count/:slug` to retrieve the total number of products for a given category
- controllers/productController.js
  - created `productCategoryCountController` for the above endpoint (will add this controller to my Trofos for further unit testing)
  - updated `productCategoryController` to support pagination
- client/src/pages/CategoryProduct.js
  - uses the updated/newly created endpoints and controllers above to support pagination
  - add "ADD TO CART" button which uses `addToCart()` from `productUtils.js`
  - add "Load more" button and "Loading..." placeholder
  - fix minor layout issue where cards are not left aligned in its row if there are not enough cards to fill up the entire row
- client/src/pages/CategoryProduct.test.js:
  - has the following structure for reference
```
CategoryProduct
├─ Data fetching & lifecycle
│  ├─ fetches count and page 1 on mount and renders products
│  ├─ refetches when slug changes and resets state
│  └─ does not fetch when slug is missing
│
├─ Rendering & content
│  ├─ shows pluralized results count
│  ├─ shows singular result count
│  ├─ renders description truncated and fallback when missing
│  ├─ shows empty state when no products and total=0
│  ├─ hides Load more when all items already loaded
│  ├─ uses 0 as total when count succeeds but total is missing
│  ├─ handles non-array products payload gracefully
│  └─ shows Load more button when not all items are loaded
│
├─ Interactions
│  ├─ navigates to product details on 'More Details'
│  ├─ calls addToCart on 'ADD TO CART'
│  └─ fetches next page, appends results, disables button while loading
│
└─ Error states
   ├─ shows error toast when count fetch fails
   ├─ shows error toast when products fetch fails (page 1) and shows empty state
   ├─ shows error toast when products fetch fails (page 2) and keeps previous products
   ├─ shows error toast with success=false in products response
   └─ shows error toast with success=false in total products response

```


## Test results
<img width="661" height="71" alt="image" src="https://github.com/user-attachments/assets/9aa115b2-9dc5-4e21-bf74-fe5c3715bbc6" />
