### PR TITLE
General - User Dashboard Tests

### DIFF
--- a/client/src/components/Routes/Private.js
+++ b/client/src/components/Routes/Private.js
@@ -1,20 +1,28 @@
-import { useState,useEffect } from "react";
+import React, { useState,useEffect} from "react";
 import { useAuth } from "../../context/auth";
 import { Outlet } from "react-router-dom";
 import axios from 'axios';
-import { set } from "mongoose";
 import Spinner from "../Spinner";
 
 export default function PrivateRoute(){
     const [ok,setOk] = useState(false)
-    const [auth,setAuth] = useAuth()
+    const [auth] = useAuth()
 
     useEffect(()=> {
         const authCheck = async() => {
-            const res = await axios.get("/api/v1/auth/user-auth");
-            if(res.data.ok){
-                setOk(true);
-            } else {
+            try {
+                const res = await axios.get("/api/v1/auth/user-auth", {
+                    headers: {
+                        Authorization: auth?.token
+                    }
+                });
+                if(res.data.ok){
+                    setOk(true);
+                } else {
+                    setOk(false);
+                }
+            } catch (error) {
+                console.log(error);
                 setOk(false);
             }
         };

--- a/client/src/components/Routes/Private.test.js
+++ b/client/src/components/Routes/Private.test.js
@@ -1,0 +1,157 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import axios from "axios";
+import PrivateRoute from "./Private";
+import { useAuth } from "../../context/auth";
+
+// Mocks
+jest.mock("axios");
+jest.mock("../../context/auth");
+jest.mock("../Spinner", () => ({ path }) => (
+  <div data-testid="spinner-mock">Redirecting to {path || "login"}</div>
+));
+
+const mockedAxios = axios;
+const mockedUseAuth = useAuth;
+
+// Test component to wrap PrivateRoute
+const TestComponent = () => (
+  <div data-testid="protected-content">Protected Content</div>
+);
+
+const renderPrivateRoute = () => {
+  return render(
+    <MemoryRouter initialEntries={["/protected"]}>
+      <Routes>
+        <Route path="/protected" element={<PrivateRoute />}>
+          <Route index element={<TestComponent />} />
+        </Route>
+      </Routes>
+    </MemoryRouter>
+  );
+};
+
+describe("PrivateRoute", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    console.log.mockRestore();
+  });
+
+  it("should render protected content when user is authenticated", async () => {
+    mockedUseAuth.mockReturnValue([{ token: "valid-token" }]);
+    mockedAxios.get.mockResolvedValue({ data: { ok: true } });
+
+    renderPrivateRoute();
+
+    // Initially shows spinner
+    expect(screen.getByTestId("spinner-mock")).toBeInTheDocument();
+
+    // Wait for auth check to complete and protected content to show
+    await waitFor(() => {
+      expect(screen.getByTestId("protected-content")).toBeInTheDocument();
+    });
+
+    expect(mockedAxios.get).toHaveBeenCalledWith("/api/v1/auth/user-auth", {
+      headers: { Authorization: "valid-token" },
+    });
+  });
+
+  it("should show spinner when user is not authenticated", async () => {
+    mockedUseAuth.mockReturnValue([{ token: "invalid-token" }]);
+    mockedAxios.get.mockResolvedValue({ data: { ok: false } });
+
+    renderPrivateRoute();
+
+    expect(screen.getByTestId("spinner-mock")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(mockedAxios.get).toHaveBeenCalledWith("/api/v1/auth/user-auth", {
+        headers: { Authorization: "invalid-token" },
+      });
+    });
+
+    // Should still show spinner, not protected content
+    expect(screen.queryByTestId("protected-content")).not.toBeInTheDocument();
+    expect(screen.getByTestId("spinner-mock")).toBeInTheDocument();
+  });
+
+  it("should handle axios request errors", async () => {
+    mockedUseAuth.mockReturnValue([{ token: "valid-token" }]);
+    const error = new Error("Network error");
+    mockedAxios.get.mockRejectedValue(error);
+
+    renderPrivateRoute();
+
+    await waitFor(() => {
+      expect(mockedAxios.get).toHaveBeenCalledWith("/api/v1/auth/user-auth", {
+        headers: { Authorization: "valid-token" },
+      });
+    });
+
+    expect(console.log).toHaveBeenCalledWith(error);
+    expect(screen.getByTestId("spinner-mock")).toBeInTheDocument();
+    expect(screen.queryByTestId("protected-content")).not.toBeInTheDocument();
+  });
+
+  it("should handle empty string token", () => {
+    mockedUseAuth.mockReturnValue([{ token: "" }]);
+
+    renderPrivateRoute();
+
+    expect(screen.getByTestId("spinner-mock")).toBeInTheDocument();
+    expect(screen.queryByTestId("protected-content")).not.toBeInTheDocument();
+    expect(mockedAxios.get).not.toHaveBeenCalled();
+  });
+
+  it("should re-check auth when token changes", async () => {
+    const { rerender } = render(
+      <MemoryRouter initialEntries={["/protected"]}>
+        <Routes>
+          <Route path="/protected" element={<PrivateRoute />}>
+            <Route index element={<TestComponent />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+
+    // First render with no token
+    mockedUseAuth.mockReturnValue([{ token: null }]);
+    rerender(
+      <MemoryRouter initialEntries={["/protected"]}>
+        <Routes>
+          <Route path="/protected" element={<PrivateRoute />}>
+            <Route index element={<TestComponent />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(mockedAxios.get).not.toHaveBeenCalled();
+
+    // Second render with valid token
+    mockedUseAuth.mockReturnValue([{ token: "new-token" }]);
+    mockedAxios.get.mockResolvedValue({ data: { ok: true } });
+
+    rerender(
+      <MemoryRouter initialEntries={["/protected"]}>
+        <Routes>
+          <Route path="/protected" element={<PrivateRoute />}>
+            <Route index element={<TestComponent />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(mockedAxios.get).toHaveBeenCalledWith("/api/v1/auth/user-auth", {
+        headers: { Authorization: "new-token" },
+      });
+    });
+  });
+});

--- a/client/src/components/UserMenu.test.js
+++ b/client/src/components/UserMenu.test.js
@@ -1,0 +1,59 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import "@testing-library/jest-dom";
+import UserMenu from "./UserMenu";
+
+describe("UserMenu", () => {
+  test("render Dashboard title", () => {
+    // ensure that the title "Dashboard" is rendered
+    render(
+      <MemoryRouter>
+        <UserMenu />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Dashboard")).toBeInTheDocument();
+  });
+
+  test("render navigation links title", () => {
+    // ensure that navigation links titles are rendered
+    render(
+      <MemoryRouter>
+        <UserMenu />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Profile")).toBeInTheDocument();
+    expect(screen.getByText("Orders")).toBeInTheDocument();
+  });
+
+  test("navigation routes", () => {
+    // ensure that each navlink maps to the correct route
+    render(
+      <MemoryRouter>
+        <UserMenu />
+      </MemoryRouter>
+    );
+
+    const profileLink = screen.getByText("Profile");
+    const ordersLink = screen.getByText("Orders");
+
+    expect(profileLink).toHaveAttribute("href", "/dashboard/user/profile");
+    expect(ordersLink).toHaveAttribute("href", "/dashboard/user/orders");
+  });
+
+  test("links accessibility", () => {
+    // ensure that each link is accessible
+    render(
+      <MemoryRouter>
+        <UserMenu />
+      </MemoryRouter>
+    );
+
+    const links = screen.getAllByRole("link");
+
+    expect(links).toHaveLength(2);
+    links.forEach((link) => expect(link).toBeVisible());
+  });
+});

--- a/client/src/pages/user/Dashboard.js
+++ b/client/src/pages/user/Dashboard.js
@@ -4,6 +4,8 @@ import UserMenu from "../../components/UserMenu";
 import { useAuth } from "../../context/auth";
 const Dashboard = () => {
   const [auth] = useAuth();
+  const user = auth?.user;
+
   return (
     <Layout title={"Dashboard - Ecommerce App"}>
       <div className="container-flui m-3 p-3 dashboard">
@@ -13,9 +15,15 @@ const Dashboard = () => {
           </div>
           <div className="col-md-9">
             <div className="card w-75 p-3">
-              <h3>{auth?.user?.name}</h3>
-              <h3>{auth?.user?.email}</h3>
-              <h3>{auth?.user?.address}</h3>
+              {user ? (
+                <>
+                  <h3>user: {user?.name || "Name Not Found"}</h3>
+                  <h3>email: {user?.email || "Email Not Found"}</h3>
+                  <h3>address: {user?.address || "Address Not Found"}</h3>
+                </>
+              ) : (
+                <h3>User Data Not Found</h3>
+              )}
             </div>
           </div>
         </div>

--- a/client/src/pages/user/Dashboard.test.js
+++ b/client/src/pages/user/Dashboard.test.js
@@ -51,4 +51,20 @@ describe("Dashboard", () => {
     expect(screen.getByText("address: 123 Main St")).toBeInTheDocument();
     expect(screen.queryByText("User Data Not Found")).not.toBeInTheDocument();
   });
+
+  it("should show fallback text when user properties are missing", () => {
+    const EMPTY_DATA_MOCK_USER = {
+      name: null,
+      email: "",
+      address: undefined,
+    };
+    mockedUseAuth.mockReturnValue([{ user: EMPTY_DATA_MOCK_USER }]);
+
+    renderDashboard();
+
+    expect(screen.getByText("user: Name Not Found")).toBeInTheDocument();
+    expect(screen.getByText("email: Email Not Found")).toBeInTheDocument();
+    expect(screen.getByText("address: Address Not Found")).toBeInTheDocument();
+    expect(screen.queryByText("User Data Not Found")).not.toBeInTheDocument();
+  });
 });

--- a/client/src/pages/user/Dashboard.test.js
+++ b/client/src/pages/user/Dashboard.test.js
@@ -67,4 +67,18 @@ describe("Dashboard", () => {
     expect(screen.getByText("address: Address Not Found")).toBeInTheDocument();
     expect(screen.queryByText("User Data Not Found")).not.toBeInTheDocument();
   });
+
+  it("should handle partial user data correctly", () => {
+    const PARTIAL_MOCK_USER = {
+      name: "Jane Smith",
+      // email and address missing
+    };
+    mockedUseAuth.mockReturnValue([{ user: PARTIAL_MOCK_USER }]);
+
+    renderDashboard();
+
+    expect(screen.getByText("user: Jane Smith")).toBeInTheDocument();
+    expect(screen.getByText("email: Email Not Found")).toBeInTheDocument();
+    expect(screen.getByText("address: Address Not Found")).toBeInTheDocument();
+  });
 });

--- a/client/src/pages/user/Dashboard.test.js
+++ b/client/src/pages/user/Dashboard.test.js
@@ -81,4 +81,13 @@ describe("Dashboard", () => {
     expect(screen.getByText("email: Email Not Found")).toBeInTheDocument();
     expect(screen.getByText("address: Address Not Found")).toBeInTheDocument();
   });
+
+  it("should show 'User Data Not Found' when user is undefined", () => {
+    mockedUseAuth.mockReturnValue([{ user: undefined }]);
+
+    renderDashboard();
+
+    expect(screen.getByText("User Data Not Found")).toBeInTheDocument();
+    expect(screen.queryByText(/user:/)).not.toBeInTheDocument();
+  });
 });

--- a/client/src/pages/user/Dashboard.test.js
+++ b/client/src/pages/user/Dashboard.test.js
@@ -1,0 +1,54 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { MemoryRouter } from "react-router-dom";
+import Dashboard from "./Dashboard";
+import { useAuth } from "../../context/auth";
+
+jest.mock("../../context/auth");
+jest.mock("../../components/Layout", () => ({ title, children }) => (
+  <div data-testid="layout-mock" title={title}>
+    {children}
+  </div>
+));
+jest.mock("../../components/UserMenu", () => () => (
+  <div data-testid="user-menu-mock">User Menu</div>
+));
+
+const mockedUseAuth = useAuth;
+
+const renderDashboard = () => {
+  return render(
+    <MemoryRouter>
+      <Dashboard />
+    </MemoryRouter>
+  );
+};
+
+describe("Dashboard", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should render user data when user exists", () => {
+    const MOCK_USER = {
+      name: "John Doe",
+      email: "john@example.com",
+      address: "123 Main St",
+    };
+    mockedUseAuth.mockReturnValue([{ user: MOCK_USER }]);
+
+    renderDashboard();
+
+    expect(screen.getByTestId("layout-mock")).toBeInTheDocument();
+    expect(screen.getByTestId("layout-mock")).toHaveAttribute(
+      "title",
+      "Dashboard - Ecommerce App"
+    );
+    expect(screen.getByTestId("user-menu-mock")).toBeInTheDocument();
+    expect(screen.getByText("user: John Doe")).toBeInTheDocument();
+    expect(screen.getByText("email: john@example.com")).toBeInTheDocument();
+    expect(screen.getByText("address: 123 Main St")).toBeInTheDocument();
+    expect(screen.queryByText("User Data Not Found")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Private 
- Fix axios get to send token in authorization header, previously was not included so honestly idk what it was doing
- Tests
  - should render protected content when user is authenticated
  - should show spinner when user is not authenticated
  - should handle axios request errors
  - should handle empty string token
  - should re-check auth when token changes
UserMenu
- No fix cause just a component with links
  - Modelled tests after AdminMenu.test.js
    - render dashboard title
    - render navigation links title
    - navigation routes
    - links accessibility (personally i feel this might be excessive)
Dashboard
- Refactor component 
  -  include fallback for user property (name, email, address)
  - use variable to store `auth?.user` instead of querying `auth?.user?.email`
  - Include fallback if `auth?.user` does not exist
- Test
  - render user data when present
  - show fallback test when user properties are missing
  - handle partial user data correctly
  - handle undefined user data