### PR TITLE
Unit testing for controllers in productController.js

### DIFF
--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -273,9 +273,9 @@ export const productListController = async (req, res) => {
     const products = await productModel
       .find({})
       .select("-photo")
+      .sort({ createdAt: -1, _id: -1 })
       .skip((page - 1) * DEFAULT_PAGE_SIZE)
-      .limit(DEFAULT_PAGE_SIZE)
-      .sort({ createdAt: -1 });
+      .limit(DEFAULT_PAGE_SIZE);
 
     res.status(200).send({
       success: true,
@@ -398,9 +398,9 @@ export const productCategoryController = async (req, res) => {
       .find({ category: category._id })
       .select("-photo")
       .populate("category")
+      .sort({ createdAt: -1, _id: -1 })
       .skip((page - 1) * limit)
-      .limit(limit)
-      .sort({ createdAt: -1 });
+      .limit(limit);
 
     res.status(200).send({
       success: true,

--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -237,7 +237,7 @@ export const productFiltersController = async (req, res) => {
     });
   } catch (error) {
     console.error(error);
-    res.status(400).send({
+    res.status(500).send({
       success: false,
       message: "Error while filtering products",
       error: error.message,
@@ -256,7 +256,7 @@ export const productCountController = async (req, res) => {
     });
   } catch (error) {
     console.error(error);
-    res.status(400).send({
+    res.status(500).send({
       message: "Error in product count",
       error: error.message,
       success: false,
@@ -282,7 +282,7 @@ export const productListController = async (req, res) => {
     });
   } catch (error) {
     console.error(error);
-    res.status(400).send({
+    res.status(500).send({
       success: false,
       message: "Error in per page product controller",
       error: error.message,
@@ -310,7 +310,7 @@ export const searchProductController = async (req, res) => {
     res.json(results);
   } catch (error) {
     console.error(error);
-    res.status(400).send({
+    res.status(500).send({
       success: false,
       message: "Error in Search Product API",
       error: error.message,
@@ -338,7 +338,7 @@ export const relatedProductController = async (req, res) => {
     });
   } catch (error) {
     console.error(error);
-    res.status(400).send({
+    res.status(500).send({
       success: false,
       message: "Error while getting related products",
       error: error.message,
@@ -377,7 +377,7 @@ export const productCategoryController = async (req, res) => {
     });
   } catch (error) {
     console.error(error);
-    res.status(400).send({
+    res.status(500).send({
       success: false,
       error: error.message,
       message: "Error while getting products by category",
@@ -405,7 +405,7 @@ export const productCategoryCountController = async (req, res) => {
     });
   } catch (error) {
     console.error(error);
-    res.status(400).send({
+    res.status(500).send({
       success: false,
       error: error.message,
       message: "Error while getting products count",

--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -385,7 +385,7 @@ export const productCategoryController = async (req, res) => {
   }
 };
 
-// get total products by category
+// Get total product count by category
 export const productCategoryCountController = async (req, res) => {
   try {
     const category = await categoryModel.findOne({ slug: req.params.slug });
@@ -397,16 +397,17 @@ export const productCategoryCountController = async (req, res) => {
     }
 
     const total = await productModel.countDocuments({ category: category._id });
+
     res.status(200).send({
       success: true,
       total,
       category,
     });
   } catch (error) {
-    console.log(error);
+    console.error(error);
     res.status(400).send({
       success: false,
-      error,
+      error: error.message,
       message: "Error while getting products count",
     });
   }

--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -245,19 +245,20 @@ export const productFiltersController = async (req, res) => {
   }
 };
 
-// product count
+// Get total product count
 export const productCountController = async (req, res) => {
   try {
-    const total = await productModel.find({}).estimatedDocumentCount();
+    const total = await productModel.estimatedDocumentCount();
+
     res.status(200).send({
       success: true,
       total,
     });
   } catch (error) {
-    console.log(error);
+    console.error(error);
     res.status(400).send({
       message: "Error in product count",
-      error,
+      error: error.message,
       success: false,
     });
   }

--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -90,24 +90,32 @@ export const getProductController = async (req, res) => {
   }
 };
 
-// get single product
+// Get single product
 export const getSingleProductController = async (req, res) => {
   try {
     const product = await productModel
       .findOne({ slug: req.params.slug })
       .select("-photo")
       .populate("category");
+
+    if (!product) {
+      return res.status(404).send({
+        success: false,
+        message: "Product not found",
+      });
+    }
+
     res.status(200).send({
       success: true,
       message: "Single Product Fetched",
       product,
     });
   } catch (error) {
-    console.log(error);
+    console.error(error);
     res.status(500).send({
       success: false,
-      message: "Eror while getitng single product",
-      error,
+      message: "Error while getting single product",
+      error: error.message,
     });
   }
 };

--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -76,7 +76,7 @@ export const getProductController = async (req, res) => {
 
     res.status(200).send({
       success: true,
-      counTotal: products.length,
+      countTotal: products.length,
       message: "All Products",
       products,
     });

--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -64,7 +64,7 @@ export const createProductController = async (req, res) => {
   }
 };
 
-// get all products
+// Get all products
 export const getProductController = async (req, res) => {
   try {
     const products = await productModel
@@ -73,17 +73,18 @@ export const getProductController = async (req, res) => {
       .select("-photo")
       .limit(12)
       .sort({ createdAt: -1 });
+
     res.status(200).send({
       success: true,
       counTotal: products.length,
-      message: "ALlProducts ",
+      message: "All Products",
       products,
     });
   } catch (error) {
-    console.log(error);
+    console.error(error);
     res.status(500).send({
       success: false,
-      message: "Erorr in getting products",
+      message: "Error getting products",
       error: error.message,
     });
   }

--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -346,7 +346,7 @@ export const relatedProductController = async (req, res) => {
   }
 };
 
-// get paginated products by category
+// Get category products by page
 export const productCategoryController = async (req, res) => {
   try {
     const category = await categoryModel.findOne({ slug: req.params.slug });
@@ -376,11 +376,11 @@ export const productCategoryController = async (req, res) => {
       limit,
     });
   } catch (error) {
-    console.log(error);
+    console.error(error);
     res.status(400).send({
       success: false,
-      error,
-      message: "Error while getting products",
+      error: error.message,
+      message: "Error while getting products by category",
     });
   }
 };

--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -120,20 +120,26 @@ export const getSingleProductController = async (req, res) => {
   }
 };
 
-// get photo
+// Get photo
 export const productPhotoController = async (req, res) => {
   try {
     const product = await productModel.findById(req.params.pid).select("photo");
-    if (product.photo.data) {
-      res.set("Content-type", product.photo.contentType);
-      return res.status(200).send(product.photo.data);
+
+    if (!product || !product.photo?.data) {
+      return res.status(404).send({
+        success: false,
+        message: "Photo not found",
+      });
     }
+
+    res.set("Content-Type", product.photo.contentType || "image/jpeg");
+    return res.status(200).send(product.photo.data);
   } catch (error) {
-    console.log(error);
+    console.error(error);
     res.status(500).send({
       success: false,
-      message: "Erorr while getting photo",
-      error,
+      message: "Error while getting photo",
+      error: error.message,
     });
   }
 };

--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -264,26 +264,28 @@ export const productCountController = async (req, res) => {
   }
 };
 
-// product list based on page
+// Get products by page
 export const productListController = async (req, res) => {
   try {
-    const page = req.params.page ? req.params.page : DEFAULT_PAGE_NUMBER;
+    const page = parseInt(req.params.page, 10) || DEFAULT_PAGE_NUMBER;
+
     const products = await productModel
       .find({})
       .select("-photo")
       .skip((page - 1) * DEFAULT_PAGE_SIZE)
       .limit(DEFAULT_PAGE_SIZE)
       .sort({ createdAt: -1 });
+
     res.status(200).send({
       success: true,
       products,
     });
   } catch (error) {
-    console.log(error);
+    console.error(error);
     res.status(400).send({
       success: false,
-      message: "error in per page ctrl",
-      error,
+      message: "Error in per page product controller",
+      error: error.message,
     });
   }
 };

--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -290,25 +290,30 @@ export const productListController = async (req, res) => {
   }
 };
 
-// search product
+// Search products by name or description
 export const searchProductController = async (req, res) => {
   try {
-    const { keyword } = req.params;
+    const searchKeyword = (req.params.keyword || "").trim();
+    if (!searchKeyword) {
+      return res.json([]);
+    }
+
     const results = await productModel
       .find({
         $or: [
-          { name: { $regex: keyword, $options: "i" } },
-          { description: { $regex: keyword, $options: "i" } },
+          { name: { $regex: searchKeyword, $options: "i" } },
+          { description: { $regex: searchKeyword, $options: "i" } },
         ],
       })
       .select("-photo");
+
     res.json(results);
   } catch (error) {
-    console.log(error);
+    console.error(error);
     res.status(400).send({
       success: false,
-      message: "Error In Search Product API",
-      error,
+      message: "Error in Search Product API",
+      error: error.message,
     });
   }
 };

--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -318,10 +318,11 @@ export const searchProductController = async (req, res) => {
   }
 };
 
-// similar products
-export const realtedProductController = async (req, res) => {
+// Get related products
+export const relatedProductController = async (req, res) => {
   try {
     const { pid, cid } = req.params;
+
     const products = await productModel
       .find({
         category: cid,
@@ -330,16 +331,17 @@ export const realtedProductController = async (req, res) => {
       .select("-photo")
       .limit(3)
       .populate("category");
+
     res.status(200).send({
       success: true,
       products,
     });
   } catch (error) {
-    console.log(error);
+    console.error(error);
     res.status(400).send({
       success: false,
-      message: "error while geting related product",
-      error,
+      message: "Error while getting related products",
+      error: error.message,
     });
   }
 };

--- a/controllers/productController.test.js
+++ b/controllers/productController.test.js
@@ -96,4 +96,19 @@ describe("getProductController", () => {
       })
     );
   });
+
+  it("handles errors with 500", async () => {
+    productModel.find.mockImplementation(() => {
+      throw new Error("Network error");
+    });
+    const req = createMockReq();
+    const res = createMockRes();
+
+    await getProductController(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.send).toHaveBeenCalledWith(
+      expect.objectContaining({ success: false })
+    );
+  });
 });

--- a/controllers/productController.test.js
+++ b/controllers/productController.test.js
@@ -56,4 +56,24 @@ describe("getProductController", () => {
       })
     );
   });
+
+  it("returns 1 product successfully", async () => {
+    const mockProducts = [{ _id: "p2" }];
+    productModel.find.mockReturnValue(makeQuery(mockProducts));
+
+    const req = createMockReq();
+    const res = createMockRes();
+
+    await getProductController(req, res);
+
+    expect(productModel.find).toHaveBeenCalledWith({});
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        products: expect.arrayContaining(mockProducts),
+        countTotal: mockProducts.length,
+      })
+    );
+  });
 });

--- a/controllers/productController.test.js
+++ b/controllers/productController.test.js
@@ -16,11 +16,15 @@ import mongoose from "mongoose";
 import productModel from "../models/productModel.js";
 import categoryModel from "../models/categoryModel.js";
 
-// Mocks
+// Module Mocks
 jest.mock("../models/productModel.js");
 jest.mock("../models/categoryModel.js");
 
-// Helper functions
+// Test Utilities
+
+/**
+ * Express response double.
+ */
 const createMockRes = () => ({
   status: jest.fn().mockReturnThis(),
   send: jest.fn().mockReturnThis(),
@@ -28,6 +32,9 @@ const createMockRes = () => ({
   set: jest.fn().mockReturnThis(),
 });
 
+/**
+ * Express request double.
+ */
 const createMockReq = (overrides = {}) => ({
   params: {},
   query: {},
@@ -37,7 +44,9 @@ const createMockReq = (overrides = {}) => ({
   ...overrides,
 });
 
-// Helper to create a mock query chain
+/**
+ * Chainable Mongoose query stub
+ */
 const makeQuery = (value) => ({
   _value: value,
   populate: jest.fn().mockReturnThis(),

--- a/controllers/productController.test.js
+++ b/controllers/productController.test.js
@@ -144,14 +144,22 @@ describe("Product controllers", () => {
   });
 
   describe("getSingleProductController", () => {
+    let res;
+
+    beforeEach(() => {
+      res = createMockRes();
+    });
+
     it("returns product successfully when found", async () => {
-      productModel.findOne.mockReturnValue(makeQuery({ _id: "p1", slug: "s" }));
-      const req = createMockReq({ params: { slug: "s" } });
-      const res = createMockRes();
+      const slug = "s";
+      const doc = { _id: "p1", slug };
+      productModel.findOne.mockReturnValue(makeQuery(doc)); // product found
+
+      const req = createMockReq({ params: { slug } });
 
       await getSingleProductController(req, res);
 
-      expect(productModel.findOne).toHaveBeenCalledWith({ slug: "s" });
+      expect(productModel.findOne).toHaveBeenCalledWith({ slug });
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.send).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -162,9 +170,10 @@ describe("Product controllers", () => {
     });
 
     it("returns 404 when product not found", async () => {
-      productModel.findOne.mockReturnValue(makeQuery(null));
-      const req = createMockReq({ params: { slug: "missing" } });
-      const res = createMockRes();
+      const slug = "missing";
+      productModel.findOne.mockReturnValue(makeQuery(null)); // product not found
+
+      const req = createMockReq({ params: { slug } });
 
       await getSingleProductController(req, res);
 
@@ -178,8 +187,8 @@ describe("Product controllers", () => {
       productModel.findOne.mockImplementation(() => {
         throw new Error("Network error");
       });
+
       const req = createMockReq();
-      const res = createMockRes();
 
       await getSingleProductController(req, res);
 

--- a/controllers/productController.test.js
+++ b/controllers/productController.test.js
@@ -411,14 +411,20 @@ describe("Product controllers", () => {
   });
 
   describe("productListController", () => {
+    let res;
+
+    beforeEach(() => {
+      res = createMockRes();
+    });
+
     it("paginates by page param", async () => {
       const docs = [{ _id: "p1" }, { _id: "p2" }];
       const pageNumber = 3;
 
       const query = makeQuery(docs);
       productModel.find.mockReturnValue(query);
+
       const req = createMockReq({ params: { page: pageNumber } });
-      const res = createMockRes();
 
       await productListController(req, res);
 
@@ -441,8 +447,8 @@ describe("Product controllers", () => {
 
       const query = makeQuery(docs);
       productModel.find.mockReturnValue(query);
+
       const req = createMockReq(); // no params.page
-      const res = createMockRes();
 
       await productListController(req, res);
 
@@ -458,11 +464,11 @@ describe("Product controllers", () => {
 
     it("defaults to page 1 for non-numeric page param", async () => {
       const docs = [{ _id: "pX" }];
+
       const query = makeQuery(docs);
       productModel.find.mockReturnValue(query);
 
-      const req = createMockReq({ params: { page: "abc" } });
-      const res = createMockRes();
+      const req = createMockReq({ params: { page: "abc" } }); // non-numeric page
 
       await productListController(req, res);
 
@@ -477,10 +483,10 @@ describe("Product controllers", () => {
       const docs = [];
       const pageNumber = 2;
 
-      const query = makeQuery(docs);
+      const query = makeQuery(docs); // no products
       productModel.find.mockReturnValue(query);
+
       const req = createMockReq({ params: { page: pageNumber } });
-      const res = createMockRes();
 
       await productListController(req, res);
 
@@ -495,8 +501,8 @@ describe("Product controllers", () => {
       productModel.find.mockImplementation(() => {
         throw new Error("Network error");
       });
+
       const req = createMockReq();
-      const res = createMockRes();
 
       await productListController(req, res);
 

--- a/controllers/productController.test.js
+++ b/controllers/productController.test.js
@@ -3,6 +3,7 @@ import {
   getSingleProductController,
   productPhotoController,
   productFiltersController,
+  productCountController,
 } from "./productController.js";
 import productModel from "../models/productModel.js";
 
@@ -282,6 +283,38 @@ describe("Product controllers", () => {
 
     it("handles errors with 500", async () => {
       productModel.find.mockImplementation(() => {
+        throw new Error("Network error");
+      });
+      const req = createMockReq();
+      const res = createMockRes();
+
+      await productFiltersController(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.send).toHaveBeenCalledWith(
+        expect.objectContaining({ success: false })
+      );
+    });
+  });
+
+  describe("productCountController", () => {
+    it("returns total count", async () => {
+      const total = 42;
+      productModel.estimatedDocumentCount.mockResolvedValueOnce(total);
+      const req = createMockReq();
+      const res = createMockRes();
+
+      await productCountController(req, res);
+
+      expect(productModel.estimatedDocumentCount).toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.send).toHaveBeenCalledWith(
+        expect.objectContaining({ total: total })
+      );
+    });
+
+    it("handles errors with 500", async () => {
+      productModel.estimatedDocumentCount.mockImplementation(() => {
         throw new Error("Network error");
       });
       const req = createMockReq();

--- a/controllers/productController.test.js
+++ b/controllers/productController.test.js
@@ -200,44 +200,51 @@ describe("Product controllers", () => {
   });
 
   describe("productPhotoController", () => {
+    let res;
+
+    beforeEach(() => {
+      res = createMockRes();
+    });
+
     it("returns photo when exists", async () => {
+      const pid = "p1";
       const buf = Buffer.from([1, 2, 3]);
       productModel.findById.mockReturnValue(
-        makeQuery({ _id: "p1", photo: { data: buf, contentType: "image/png" } })
-      );
-      const req = createMockReq({ params: { pid: "p1" } });
-      const res = createMockRes();
+        makeQuery({ _id: pid, photo: { data: buf, contentType: "image/png" } })
+      ); // photo exists
+
+      const req = createMockReq({ params: { pid } });
 
       await productPhotoController(req, res);
 
-      expect(productModel.findById).toHaveBeenCalledWith("p1");
+      expect(productModel.findById).toHaveBeenCalledWith(pid);
       expect(res.set).toHaveBeenCalledWith("Content-Type", "image/png");
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.send).toHaveBeenCalledWith(buf);
     });
 
     it("defaults content-type to image/jpeg when missing", async () => {
+      const pid = "p2";
       const buf = Buffer.from([4, 5, 6]);
       productModel.findById.mockReturnValue(
-        makeQuery({ _id: "p2", photo: { data: buf } })
-      );
-      const req = createMockReq({ params: { pid: "p2" } });
-      const res = createMockRes();
+        makeQuery({ _id: pid, photo: { data: buf } })
+      ); // photo exists, but contentType missing
+
+      const req = createMockReq({ params: { pid } });
 
       await productPhotoController(req, res);
 
-      expect(productModel.findById).toHaveBeenCalledWith("p2");
+      expect(productModel.findById).toHaveBeenCalledWith(pid);
       expect(res.set).toHaveBeenCalledWith("Content-Type", "image/jpeg");
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.send).toHaveBeenCalledWith(buf);
     });
 
     it("returns 404 when no photo found", async () => {
-      productModel.findById.mockReturnValue(
-        makeQuery({ _id: "p1", photo: {} })
-      );
-      const req = createMockReq({ params: { pid: "p1" } });
-      const res = createMockRes();
+      const pid = "p1";
+      productModel.findById.mockReturnValue(makeQuery({ _id: pid, photo: {} })); // no photo
+
+      const req = createMockReq({ params: { pid } });
 
       await productPhotoController(req, res);
 
@@ -248,8 +255,8 @@ describe("Product controllers", () => {
       productModel.findById.mockImplementation(() => {
         throw new Error("Network error");
       });
+
       const req = createMockReq();
-      const res = createMockRes();
 
       await productPhotoController(req, res);
 

--- a/controllers/productController.test.js
+++ b/controllers/productController.test.js
@@ -76,4 +76,24 @@ describe("getProductController", () => {
       })
     );
   });
+
+  it("returns more than 1 products successfully", async () => {
+    const mockProducts = [{ _id: "p1" }, { _id: "p2" }];
+    productModel.find.mockReturnValue(makeQuery(mockProducts));
+
+    const req = createMockReq();
+    const res = createMockRes();
+
+    await getProductController(req, res);
+
+    expect(productModel.find).toHaveBeenCalledWith({});
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        products: expect.arrayContaining(mockProducts),
+        countTotal: mockProducts.length,
+      })
+    );
+  });
 });

--- a/controllers/productController.test.js
+++ b/controllers/productController.test.js
@@ -884,19 +884,27 @@ describe("Product controllers", () => {
   });
 
   describe("productCategoryCountController", () => {
+    // Common params for this suite
+    const slug = "shirts";
+    const categoryId = "cat1";
+
+    let res;
+
+    beforeEach(() => {
+      res = createMockRes();
+    });
+
     it("returns count for category", async () => {
       const count = 7;
-      const shirtSlug = "shirts";
-      const categoryId = "cat1";
 
       categoryModel.findOne.mockReturnValue(makeQuery({ _id: categoryId }));
       productModel.countDocuments.mockResolvedValueOnce(count);
-      const req = createMockReq({ params: { slug: shirtSlug } });
-      const res = createMockRes();
+
+      const req = createMockReq({ params: { slug } });
 
       await productCategoryCountController(req, res);
 
-      expect(categoryModel.findOne).toHaveBeenCalledWith({ slug: shirtSlug });
+      expect(categoryModel.findOne).toHaveBeenCalledWith({ slug });
       expect(productModel.countDocuments).toHaveBeenCalledWith({
         category: categoryId,
       });
@@ -907,9 +915,9 @@ describe("Product controllers", () => {
     });
 
     it("returns 404 when category is missing", async () => {
-      categoryModel.findOne.mockReturnValue(makeQuery(null));
+      categoryModel.findOne.mockReturnValue(makeQuery(null)); // category does not exist
+
       const req = createMockReq({ params: { slug: "missing" } });
-      const res = createMockRes();
 
       await productCategoryCountController(req, res);
 
@@ -920,8 +928,8 @@ describe("Product controllers", () => {
       categoryModel.findOne.mockImplementation(() => {
         throw new Error("Network error");
       });
+
       const req = createMockReq();
-      const res = createMockRes();
 
       await productCategoryCountController(req, res);
 

--- a/controllers/productController.test.js
+++ b/controllers/productController.test.js
@@ -64,11 +64,17 @@ describe("Product controllers", () => {
   });
 
   describe("getProductController", () => {
+    let res;
+
+    beforeEach(() => {
+      res = createMockRes();
+    });
+
     it("returns 0 product successfully", async () => {
-      const mockProducts = [];
-      productModel.find.mockReturnValue(makeQuery(mockProducts));
+      const products = []; // no products
+      productModel.find.mockReturnValue(makeQuery(products));
+
       const req = createMockReq();
-      const res = createMockRes();
 
       await getProductController(req, res);
 
@@ -77,17 +83,17 @@ describe("Product controllers", () => {
       expect(res.send).toHaveBeenCalledWith(
         expect.objectContaining({
           success: true,
-          products: expect.arrayContaining(mockProducts),
-          countTotal: mockProducts.length,
+          products: expect.arrayContaining(products),
+          countTotal: products.length,
         })
       );
     });
 
     it("returns 1 product successfully", async () => {
-      const mockProducts = [{ _id: "p2" }];
-      productModel.find.mockReturnValue(makeQuery(mockProducts));
+      const products = [{ _id: "p2" }]; // single product
+      productModel.find.mockReturnValue(makeQuery(products));
+
       const req = createMockReq();
-      const res = createMockRes();
 
       await getProductController(req, res);
 
@@ -96,17 +102,17 @@ describe("Product controllers", () => {
       expect(res.send).toHaveBeenCalledWith(
         expect.objectContaining({
           success: true,
-          products: expect.arrayContaining(mockProducts),
-          countTotal: mockProducts.length,
+          products: expect.arrayContaining(products),
+          countTotal: products.length,
         })
       );
     });
 
     it("returns more than 1 products successfully", async () => {
-      const mockProducts = [{ _id: "p1" }, { _id: "p2" }];
-      productModel.find.mockReturnValue(makeQuery(mockProducts));
+      const products = [{ _id: "p1" }, { _id: "p2" }]; // multiple products
+      productModel.find.mockReturnValue(makeQuery(products));
+
       const req = createMockReq();
-      const res = createMockRes();
 
       await getProductController(req, res);
 
@@ -115,8 +121,8 @@ describe("Product controllers", () => {
       expect(res.send).toHaveBeenCalledWith(
         expect.objectContaining({
           success: true,
-          products: expect.arrayContaining(mockProducts),
-          countTotal: mockProducts.length,
+          products: expect.arrayContaining(products),
+          countTotal: products.length,
         })
       );
     });
@@ -125,8 +131,8 @@ describe("Product controllers", () => {
       productModel.find.mockImplementation(() => {
         throw new Error("Network error");
       });
+
       const req = createMockReq();
-      const res = createMockRes();
 
       await getProductController(req, res);
 

--- a/controllers/productController.test.js
+++ b/controllers/productController.test.js
@@ -274,6 +274,22 @@ describe("Product controllers", () => {
       );
     });
 
+    it("does not filter by price when price range is NaN", async () => {
+      productModel.find.mockReturnValue(makeQuery(result));
+      const req = createMockReq({
+        body: { radio: ["abc", "def"] },
+      });
+      const res = createMockRes();
+
+      await productFiltersController(req, res);
+
+      expect(productModel.find).toHaveBeenCalledWith({});
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.send).toHaveBeenCalledWith(
+        expect.objectContaining({ products: result })
+      );
+    });
+
     it("handles no filters gracefully", async () => {
       const result = [];
 

--- a/controllers/productController.test.js
+++ b/controllers/productController.test.js
@@ -430,7 +430,7 @@ describe("Product controllers", () => {
 
       expect(productModel.find).toHaveBeenCalledWith({});
       expect(query.select).toHaveBeenCalledWith("-photo");
-      expect(query.sort).toHaveBeenCalledWith({ createdAt: -1 });
+      expect(query.sort).toHaveBeenCalledWith({ createdAt: -1, _id: -1 });
       expect(query.limit).toHaveBeenCalledWith(DEFAULT_PAGE_SIZE);
       expect(query.skip).toHaveBeenCalledWith(
         (pageNumber - 1) * DEFAULT_PAGE_SIZE
@@ -751,7 +751,7 @@ describe("Product controllers", () => {
       expect(query.populate).toHaveBeenCalledWith("category");
       expect(query.limit).toHaveBeenCalledWith(limit);
       expect(query.skip).toHaveBeenCalledWith((page - 1) * limit);
-      expect(query.sort).toHaveBeenCalledWith({ createdAt: -1 });
+      expect(query.sort).toHaveBeenCalledWith({ createdAt: -1, _id: -1 });
 
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.send).toHaveBeenCalledWith(

--- a/controllers/productController.test.js
+++ b/controllers/productController.test.js
@@ -32,83 +32,85 @@ const makeQuery = (value) => ({
   catch: (reject) => Promise.resolve(value).catch(reject),
 });
 
-describe("getProductController", () => {
+describe("Product controllers", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it("returns 0 product successfully", async () => {
-    const mockProducts = [];
-    productModel.find.mockReturnValue(makeQuery(mockProducts));
+  describe("getProductController", () => {
+    it("returns 0 product successfully", async () => {
+      const mockProducts = [];
+      productModel.find.mockReturnValue(makeQuery(mockProducts));
 
-    const req = createMockReq();
-    const res = createMockRes();
+      const req = createMockReq();
+      const res = createMockRes();
 
-    await getProductController(req, res);
+      await getProductController(req, res);
 
-    expect(productModel.find).toHaveBeenCalledWith({});
-    expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.send).toHaveBeenCalledWith(
-      expect.objectContaining({
-        success: true,
-        products: expect.arrayContaining(mockProducts),
-        countTotal: mockProducts.length,
-      })
-    );
-  });
-
-  it("returns 1 product successfully", async () => {
-    const mockProducts = [{ _id: "p2" }];
-    productModel.find.mockReturnValue(makeQuery(mockProducts));
-
-    const req = createMockReq();
-    const res = createMockRes();
-
-    await getProductController(req, res);
-
-    expect(productModel.find).toHaveBeenCalledWith({});
-    expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.send).toHaveBeenCalledWith(
-      expect.objectContaining({
-        success: true,
-        products: expect.arrayContaining(mockProducts),
-        countTotal: mockProducts.length,
-      })
-    );
-  });
-
-  it("returns more than 1 products successfully", async () => {
-    const mockProducts = [{ _id: "p1" }, { _id: "p2" }];
-    productModel.find.mockReturnValue(makeQuery(mockProducts));
-
-    const req = createMockReq();
-    const res = createMockRes();
-
-    await getProductController(req, res);
-
-    expect(productModel.find).toHaveBeenCalledWith({});
-    expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.send).toHaveBeenCalledWith(
-      expect.objectContaining({
-        success: true,
-        products: expect.arrayContaining(mockProducts),
-        countTotal: mockProducts.length,
-      })
-    );
-  });
-
-  it("handles errors with 500", async () => {
-    productModel.find.mockImplementation(() => {
-      throw new Error("Network error");
+      expect(productModel.find).toHaveBeenCalledWith({});
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          products: expect.arrayContaining(mockProducts),
+          countTotal: mockProducts.length,
+        })
+      );
     });
-    const req = createMockReq();
-    const res = createMockRes();
 
-    await getProductController(req, res);
+    it("returns 1 product successfully", async () => {
+      const mockProducts = [{ _id: "p2" }];
+      productModel.find.mockReturnValue(makeQuery(mockProducts));
 
-    expect(res.status).toHaveBeenCalledWith(500);
-    expect(res.send).toHaveBeenCalledWith(
-      expect.objectContaining({ success: false })
-    );
+      const req = createMockReq();
+      const res = createMockRes();
+
+      await getProductController(req, res);
+
+      expect(productModel.find).toHaveBeenCalledWith({});
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          products: expect.arrayContaining(mockProducts),
+          countTotal: mockProducts.length,
+        })
+      );
+    });
+
+    it("returns more than 1 products successfully", async () => {
+      const mockProducts = [{ _id: "p1" }, { _id: "p2" }];
+      productModel.find.mockReturnValue(makeQuery(mockProducts));
+
+      const req = createMockReq();
+      const res = createMockRes();
+
+      await getProductController(req, res);
+
+      expect(productModel.find).toHaveBeenCalledWith({});
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          products: expect.arrayContaining(mockProducts),
+          countTotal: mockProducts.length,
+        })
+      );
+    });
+
+    it("handles errors with 500", async () => {
+      productModel.find.mockImplementation(() => {
+        throw new Error("Network error");
+      });
+      const req = createMockReq();
+      const res = createMockRes();
+
+      await getProductController(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.send).toHaveBeenCalledWith(
+        expect.objectContaining({ success: false })
+      );
+    });
   });
 });

--- a/controllers/productController.test.js
+++ b/controllers/productController.test.js
@@ -375,28 +375,31 @@ describe("Product controllers", () => {
   });
 
   describe("productCountController", () => {
+    let res;
+
+    beforeEach(() => {
+      res = createMockRes();
+    });
+
     it("returns total count", async () => {
       const total = 42;
-
       productModel.estimatedDocumentCount.mockResolvedValueOnce(total);
+
       const req = createMockReq();
-      const res = createMockRes();
 
       await productCountController(req, res);
 
       expect(productModel.estimatedDocumentCount).toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(200);
-      expect(res.send).toHaveBeenCalledWith(
-        expect.objectContaining({ total: total })
-      );
+      expect(res.send).toHaveBeenCalledWith(expect.objectContaining({ total }));
     });
 
     it("handles errors with 500", async () => {
       productModel.estimatedDocumentCount.mockImplementation(() => {
         throw new Error("Network error");
       });
+
       const req = createMockReq();
-      const res = createMockRes();
 
       await productCountController(req, res);
 

--- a/controllers/productController.test.js
+++ b/controllers/productController.test.js
@@ -149,5 +149,20 @@ describe("Product controllers", () => {
         expect.objectContaining({ success: false })
       );
     });
+
+    it("handles errors with 500", async () => {
+      productModel.findOne.mockImplementation(() => {
+        throw new Error("Network error");
+      });
+      const req = createMockReq();
+      const res = createMockRes();
+
+      await getSingleProductController(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.send).toHaveBeenCalledWith(
+        expect.objectContaining({ success: false })
+      );
+    });
   });
 });

--- a/controllers/productController.test.js
+++ b/controllers/productController.test.js
@@ -1,6 +1,7 @@
 import {
   getProductController,
   getSingleProductController,
+  productPhotoController,
 } from "./productController.js";
 import productModel from "../models/productModel.js";
 
@@ -44,7 +45,6 @@ describe("Product controllers", () => {
     it("returns 0 product successfully", async () => {
       const mockProducts = [];
       productModel.find.mockReturnValue(makeQuery(mockProducts));
-
       const req = createMockReq();
       const res = createMockRes();
 
@@ -64,7 +64,6 @@ describe("Product controllers", () => {
     it("returns 1 product successfully", async () => {
       const mockProducts = [{ _id: "p2" }];
       productModel.find.mockReturnValue(makeQuery(mockProducts));
-
       const req = createMockReq();
       const res = createMockRes();
 
@@ -84,7 +83,6 @@ describe("Product controllers", () => {
     it("returns more than 1 products successfully", async () => {
       const mockProducts = [{ _id: "p1" }, { _id: "p2" }];
       productModel.find.mockReturnValue(makeQuery(mockProducts));
-
       const req = createMockReq();
       const res = createMockRes();
 
@@ -120,7 +118,6 @@ describe("Product controllers", () => {
   describe("getSingleProductController", () => {
     it("returns product successfully when found", async () => {
       productModel.findOne.mockReturnValue(makeQuery({ _id: "p1", slug: "s" }));
-
       const req = createMockReq({ params: { slug: "s" } });
       const res = createMockRes();
 
@@ -138,7 +135,6 @@ describe("Product controllers", () => {
 
     it("returns 404 when product not found", async () => {
       productModel.findOne.mockReturnValue(makeQuery(null));
-
       const req = createMockReq({ params: { slug: "missing" } });
       const res = createMockRes();
 
@@ -163,6 +159,24 @@ describe("Product controllers", () => {
       expect(res.send).toHaveBeenCalledWith(
         expect.objectContaining({ success: false })
       );
+    });
+  });
+
+  describe("productPhotoController", () => {
+    it("returns photo when exists", async () => {
+      const buf = Buffer.from([1, 2, 3]);
+      productModel.findById.mockReturnValue(
+        makeQuery({ _id: "p1", photo: { data: buf, contentType: "image/png" } })
+      );
+      const req = createMockReq({ params: { pid: "p1" } });
+      const res = createMockRes();
+
+      await productPhotoController(req, res);
+
+      expect(productModel.findById).toHaveBeenCalledWith("p1");
+      expect(res.set).toHaveBeenCalledWith("Content-Type", "image/png");
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.send).toHaveBeenCalledWith(buf);
     });
   });
 });

--- a/controllers/productController.test.js
+++ b/controllers/productController.test.js
@@ -268,16 +268,21 @@ describe("Product controllers", () => {
   });
 
   describe("productFiltersController", () => {
+    let res;
     const categories = ["c1", "c2"];
     const priceRange = [40, 59];
-    const result = [{ _id: "p1" }];
+
+    beforeEach(() => {
+      res = createMockRes();
+    });
 
     it("filters by categories and price range", async () => {
+      const result = [{ _id: "p1" }];
       productModel.find.mockReturnValue(makeQuery(result));
+
       const req = createMockReq({
         body: { checked: categories, radio: priceRange },
       });
-      const res = createMockRes();
 
       await productFiltersController(req, res);
 
@@ -292,11 +297,10 @@ describe("Product controllers", () => {
     });
 
     it("filters by categories only", async () => {
+      const result = [{ _id: "p1" }];
       productModel.find.mockReturnValue(makeQuery(result));
-      const req = createMockReq({
-        body: { checked: categories },
-      });
-      const res = createMockRes();
+
+      const req = createMockReq({ body: { checked: categories } });
 
       await productFiltersController(req, res);
 
@@ -309,12 +313,11 @@ describe("Product controllers", () => {
       );
     });
 
-    it("filters price range only", async () => {
+    it("filters by price range only", async () => {
+      const result = [{ _id: "p1" }];
       productModel.find.mockReturnValue(makeQuery(result));
-      const req = createMockReq({
-        body: { radio: priceRange },
-      });
-      const res = createMockRes();
+
+      const req = createMockReq({ body: { radio: priceRange } });
 
       await productFiltersController(req, res);
 
@@ -327,16 +330,16 @@ describe("Product controllers", () => {
       );
     });
 
-    it("does not filter by price when for non-numeric price range", async () => {
+    it("does not filter by price for non-numeric price range", async () => {
+      const result = [{ _id: "p1" }];
       productModel.find.mockReturnValue(makeQuery(result));
-      const req = createMockReq({
-        body: { radio: ["abc", "def"] },
-      }); // contains non-numeric price filter
-      const res = createMockRes();
+
+      const req = createMockReq({ body: { radio: ["abc", "def"] } }); // non-numeric price range
 
       await productFiltersController(req, res);
 
-      expect(productModel.find).toHaveBeenCalledWith({}); // no filters
+      // Falls back to no filters
+      expect(productModel.find).toHaveBeenCalledWith({});
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.send).toHaveBeenCalledWith(
         expect.objectContaining({ products: result })
@@ -345,10 +348,9 @@ describe("Product controllers", () => {
 
     it("handles no filters gracefully", async () => {
       const result = [];
-
       productModel.find.mockReturnValue(makeQuery(result));
-      const req = createMockReq({ body: {} });
-      const res = createMockRes();
+
+      const req = createMockReq({ body: {} }); // no filters
 
       await productFiltersController(req, res);
 
@@ -360,8 +362,8 @@ describe("Product controllers", () => {
       productModel.find.mockImplementation(() => {
         throw new Error("Network error");
       });
+
       const req = createMockReq();
-      const res = createMockRes();
 
       await productFiltersController(req, res);
 

--- a/controllers/productController.test.js
+++ b/controllers/productController.test.js
@@ -178,5 +178,17 @@ describe("Product controllers", () => {
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.send).toHaveBeenCalledWith(buf);
     });
+
+    it("returns 404 when no photo found", async () => {
+      productModel.findById.mockReturnValue(
+        makeQuery({ _id: "p1", photo: {} })
+      );
+      const req = createMockReq({ params: { pid: "p1" } });
+      const res = createMockRes();
+
+      await productPhotoController(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
   });
 });

--- a/controllers/productController.test.js
+++ b/controllers/productController.test.js
@@ -1,3 +1,4 @@
+import { getProductController } from "./productController.js";
 import productModel from "../models/productModel.js";
 
 // Mocks
@@ -29,4 +30,30 @@ const makeQuery = (value) => ({
   sort: jest.fn().mockReturnThis(),
   then: (resolve) => Promise.resolve(value).then(resolve),
   catch: (reject) => Promise.resolve(value).catch(reject),
+});
+
+describe("getProductController", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns 0 product successfully", async () => {
+    const mockProducts = [];
+    productModel.find.mockReturnValue(makeQuery(mockProducts));
+
+    const req = createMockReq();
+    const res = createMockRes();
+
+    await getProductController(req, res);
+
+    expect(productModel.find).toHaveBeenCalledWith({});
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        products: expect.arrayContaining(mockProducts),
+        countTotal: mockProducts.length,
+      })
+    );
+  });
 });

--- a/controllers/productController.test.js
+++ b/controllers/productController.test.js
@@ -190,5 +190,20 @@ describe("Product controllers", () => {
 
       expect(res.status).toHaveBeenCalledWith(404);
     });
+
+    it("handles errors with 500", async () => {
+      productModel.findById.mockImplementation(() => {
+        throw new Error("Network error");
+      });
+      const req = createMockReq();
+      const res = createMockRes();
+
+      await getProductController(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.send).toHaveBeenCalledWith(
+        expect.objectContaining({ success: false })
+      );
+    });
   });
 });

--- a/controllers/productController.test.js
+++ b/controllers/productController.test.js
@@ -1,0 +1,32 @@
+import productModel from "../models/productModel.js";
+
+// Mocks
+jest.mock("../models/productModel.js");
+
+// Helper functions
+const createMockRes = () => ({
+  status: jest.fn().mockReturnThis(),
+  send: jest.fn().mockReturnThis(),
+  json: jest.fn().mockReturnThis(),
+  set: jest.fn().mockReturnThis(),
+});
+
+const createMockReq = (overrides = {}) => ({
+  params: {},
+  query: {},
+  body: {},
+  fields: {},
+  files: {},
+  ...overrides,
+});
+
+const makeQuery = (value) => ({
+  _value: value,
+  populate: jest.fn().mockReturnThis(),
+  select: jest.fn().mockReturnThis(),
+  limit: jest.fn().mockReturnThis(),
+  skip: jest.fn().mockReturnThis(),
+  sort: jest.fn().mockReturnThis(),
+  then: (resolve) => Promise.resolve(value).then(resolve),
+  catch: (reject) => Promise.resolve(value).catch(reject),
+});

--- a/controllers/productController.test.js
+++ b/controllers/productController.test.js
@@ -1,4 +1,7 @@
-import { getProductController } from "./productController.js";
+import {
+  getProductController,
+  getSingleProductController,
+} from "./productController.js";
 import productModel from "../models/productModel.js";
 
 // Mocks
@@ -110,6 +113,26 @@ describe("Product controllers", () => {
       expect(res.status).toHaveBeenCalledWith(500);
       expect(res.send).toHaveBeenCalledWith(
         expect.objectContaining({ success: false })
+      );
+    });
+  });
+
+  describe("getSingleProductController", () => {
+    it("returns product successfully when found", async () => {
+      productModel.findOne.mockReturnValue(makeQuery({ _id: "p1", slug: "s" }));
+
+      const req = createMockReq({ params: { slug: "s" } });
+      const res = createMockRes();
+
+      await getSingleProductController(req, res);
+
+      expect(productModel.findOne).toHaveBeenCalledWith({ slug: "s" });
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          product: expect.objectContaining({ _id: "p1" }),
+        })
       );
     });
   });

--- a/controllers/productController.test.js
+++ b/controllers/productController.test.js
@@ -514,11 +514,15 @@ describe("Product controllers", () => {
   });
 
   describe("searchProductController", () => {
-    it("returns [] for keyword with whitespaces only", async () => {
-      const whitespaceKeyword = "   ";
+    let res;
 
-      const req = createMockReq({ params: { keyword: whitespaceKeyword } });
-      const res = createMockRes();
+    beforeEach(() => {
+      res = createMockRes();
+    });
+
+    it("returns [] for keyword with whitespaces only", async () => {
+      const keyword = "   "; // only spaces
+      const req = createMockReq({ params: { keyword } });
 
       await searchProductController(req, res);
 
@@ -527,42 +531,40 @@ describe("Product controllers", () => {
     });
 
     it("returns [] for empty string keyword", async () => {
-      const emptyKeyword = "";
-      const req = createMockReq({ params: { keyword: emptyKeyword } });
-      const res = createMockRes();
+      const keyword = ""; // empty string
+      const req = createMockReq({ params: { keyword } });
 
       await searchProductController(req, res);
+
       expect(res.json).toHaveBeenCalledWith([]);
       expect(productModel.find).not.toHaveBeenCalled();
     });
 
     it("searches by name/description", async () => {
-      const searchKeyword = "phone";
+      const keyword = "phone";
       const result = [{ _id: "p" }];
-
       productModel.find.mockReturnValue(makeQuery(result));
-      const req = createMockReq({ params: { keyword: searchKeyword } });
-      const res = createMockRes();
+
+      const req = createMockReq({ params: { keyword } });
 
       await searchProductController(req, res);
 
       expect(productModel.find).toHaveBeenCalledWith({
         $or: [
-          { name: { $regex: searchKeyword, $options: "i" } },
-          { description: { $regex: searchKeyword, $options: "i" } },
+          { name: { $regex: keyword, $options: "i" } },
+          { description: { $regex: keyword, $options: "i" } },
         ],
       });
       expect(res.json).toHaveBeenCalledWith(result);
     });
 
     it("handles errors with 500", async () => {
-      const searchKeyword = "phone";
-
+      const keyword = "phone";
       productModel.find.mockImplementation(() => {
         throw new Error("Network error");
       });
-      const req = createMockReq({ params: { keyword: searchKeyword } });
-      const res = createMockRes();
+
+      const req = createMockReq({ params: { keyword } });
 
       await searchProductController(req, res);
 

--- a/controllers/productController.test.js
+++ b/controllers/productController.test.js
@@ -135,5 +135,19 @@ describe("Product controllers", () => {
         })
       );
     });
+
+    it("returns 404 when product not found", async () => {
+      productModel.findOne.mockReturnValue(makeQuery(null));
+
+      const req = createMockReq({ params: { slug: "missing" } });
+      const res = createMockRes();
+
+      await getSingleProductController(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.send).toHaveBeenCalledWith(
+        expect.objectContaining({ success: false })
+      );
+    });
   });
 });

--- a/controllers/productController.test.js
+++ b/controllers/productController.test.js
@@ -205,7 +205,7 @@ describe("Product controllers", () => {
       const req = createMockReq();
       const res = createMockRes();
 
-      await getProductController(req, res);
+      await productPhotoController(req, res);
 
       expect(res.status).toHaveBeenCalledWith(500);
       expect(res.send).toHaveBeenCalledWith(
@@ -327,7 +327,7 @@ describe("Product controllers", () => {
       const req = createMockReq();
       const res = createMockRes();
 
-      await productFiltersController(req, res);
+      await productCountController(req, res);
 
       expect(res.status).toHaveBeenCalledWith(500);
       expect(res.send).toHaveBeenCalledWith(
@@ -337,14 +337,24 @@ describe("Product controllers", () => {
   });
 
   describe("searchProductController", () => {
-    it("returns [] for blank keyword", async () => {
-      const blankKeyword = "   ";
+    it("returns [] for keyword with whitespaces only", async () => {
+      const whitespaceKeyword = "   ";
 
-      const req = createMockReq({ params: { keyword: blankKeyword } });
+      const req = createMockReq({ params: { keyword: whitespaceKeyword } });
       const res = createMockRes();
 
       await searchProductController(req, res);
 
+      expect(res.json).toHaveBeenCalledWith([]);
+      expect(productModel.find).not.toHaveBeenCalled();
+    });
+
+    it("returns [] for empty string keyword", async () => {
+      const emptyKeyword = "";
+      const req = createMockReq({ params: { keyword: emptyKeyword } });
+      const res = createMockRes();
+
+      await searchProductController(req, res);
       expect(res.json).toHaveBeenCalledWith([]);
       expect(productModel.find).not.toHaveBeenCalled();
     });

--- a/routes/productRoutes.js
+++ b/routes/productRoutes.js
@@ -12,7 +12,7 @@ import {
   productFiltersController,
   productListController,
   productPhotoController,
-  realtedProductController,
+  relatedProductController,
   searchProductController,
   updateProductController,
 } from "../controllers/productController.js";
@@ -63,16 +63,13 @@ router.get("/product-list/:page", productListController);
 router.get("/search/:keyword", searchProductController);
 
 //similar product
-router.get("/related-product/:pid/:cid", realtedProductController);
+router.get("/related-product/:pid/:cid", relatedProductController);
 
 //category wise product
 router.get("/product-category/:slug", productCategoryController);
 
 //category wise product count
-router.get(
-  "/product-category-count/:slug",
-  productCategoryCountController
-);
+router.get("/product-category-count/:slug", productCategoryCountController);
 
 //payments routes
 //token


### PR DESCRIPTION
## Outline
This PR introduces unit testing and the relevant fixes for the following controllers:
- getProductController
- getSingleProductController
- productPhotoController
- productFiltersController
- productCountController
- productListController
- searchProductController
- relatedProductController
- productCategoryController
- productCategoryCountController

PR is quite big but quite repititive, here is the general structure for the test suite of a single controller:
- 1 or more test cases for happy path (200 ok), may have more test cases if there are multiple equivalence classes
- 1 or more test cases for 4XX errors (e.g. missing param or resource does not exist in DB)
- 1 final test case for 500 error (catch all)

## Results
- 100% statement/branch/function/line coverage for the above controllers
- all test cases pass too

