### PR TITLE
Fix truncating of description

### DIFF
--- a/client/src/pages/CartPage.js
+++ b/client/src/pages/CartPage.js
@@ -8,6 +8,7 @@ import { AiFillWarning } from "react-icons/ai";
 import axios from "axios";
 import toast from "react-hot-toast";
 import "../styles/CartStyles.css";
+import { truncateDescription30 } from "../utils/productUtils";
 
 const CartPage = () => {
   const [auth, setAuth] = useAuth();
@@ -66,7 +67,9 @@ const CartPage = () => {
   // verify sufficient quantity
   const verifyQuantity = async (items) => {
     try {
-      const { data } = await axios.post("/api/v1/product/check-inventory", { cart: items });
+      const { data } = await axios.post("/api/v1/product/check-inventory", {
+        cart: items,
+      });
       return data;
     } catch (error) {
       return {
@@ -92,7 +95,9 @@ const CartPage = () => {
         toast.error(
           qtyCheck?.itemId
             ? `${base} (Item: ${qtyCheck.itemId}${
-                Number.isFinite(qtyCheck.available) ? `, available: ${qtyCheck.available}` : ""
+                Number.isFinite(qtyCheck.available)
+                  ? `, available: ${qtyCheck.available}`
+                  : ""
               })`
             : base
         );
@@ -154,7 +159,7 @@ const CartPage = () => {
                   </div>
                   <div className="col-md-4">
                     <p>{p.name}</p>
-                    <p>{p.description.substring(0, 30)}</p>
+                    <p>{truncateDescription30(p.description)}</p>
                     <p>Price : {p.price}</p>
                   </div>
                   <div className="col-md-4 cart-remove-btn">

--- a/client/src/pages/CategoryProduct.js
+++ b/client/src/pages/CategoryProduct.js
@@ -10,6 +10,7 @@ import {
   getImageUrl,
   addToCart,
   handleImgError,
+  truncateDescription60,
 } from "../utils/productUtils";
 import { AiOutlineReload } from "react-icons/ai";
 
@@ -117,9 +118,7 @@ const CategoryProduct = () => {
                     </div>
                     <p className="card-text">
                       {p.description
-                        ? p.description.length <= 60
-                          ? p.description
-                          : p.description.substring(0, 60) + "..."
+                        ? truncateDescription60(p.description)
                         : "No description available"}
                     </p>
                     <div className="card-name-price">

--- a/client/src/pages/CategoryProduct.test.js
+++ b/client/src/pages/CategoryProduct.test.js
@@ -29,12 +29,16 @@ jest.mock("../context/cart", () => ({
 
 jest.mock("react-hot-toast");
 
-jest.mock("../utils/productUtils", () => ({
-  formatPrice: (n) => `$${Number(n).toFixed(2)}`,
-  getImageUrl: (id) => `/img/${id}`,
-  addToCart: jest.fn(),
-  handleImgError: jest.fn(),
-}));
+jest.mock("../utils/productUtils", () => {
+  const actual = jest.requireActual("../utils/productUtils");
+  return {
+    ...actual,
+    formatPrice: (n) => `$${Number(n).toFixed(2)}`,
+    getImageUrl: (id) => `/img/${id}`,
+    addToCart: jest.fn(),
+    handleImgError: jest.fn(),
+  };
+});
 
 const SLUG_SHIRTS = "shirts";
 const SLUG_PANTS = "pants";
@@ -199,32 +203,6 @@ describe("CategoryProduct", () => {
 
       renderWithRouter(<CategoryProduct />);
       expect(await screen.findByText(/1 result found/i)).toBeInTheDocument(); // singular "result"
-    });
-
-    it("renders truncated description when missing", async () => {
-      const longDesc =
-        "This is a very long description that should be truncated at sixty characters to keep the card compact.";
-      const products = [
-        makeProduct({ name: "LongDesc", description: longDesc }),
-      ];
-
-      axios.get
-        .mockResolvedValueOnce({ data: { success: true, total: 1 } })
-        .mockResolvedValueOnce({
-          data: {
-            success: true,
-            category: { name: CATEGORY_SHIRTS },
-            products,
-          },
-        });
-
-      renderWithRouter(<CategoryProduct />);
-
-      await screen.findByText(`Category - ${CATEGORY_SHIRTS}`);
-
-      const truncated = longDesc.substring(0, 60) + "...";
-      expect(screen.getByText(truncated)).toBeInTheDocument();
-      expect(screen.queryByText(longDesc)).not.toBeInTheDocument();
     });
 
     it("renders fallback description when missing", async () => {

--- a/client/src/pages/HomePage.js
+++ b/client/src/pages/HomePage.js
@@ -3,13 +3,12 @@ import { useNavigate } from "react-router-dom";
 import { Checkbox, Radio } from "antd";
 import { Prices } from "../components/Prices";
 import { useCart } from "../context/cart";
-import { addToCart } from '../utils/productUtils';
+import { addToCart, truncateDescription60 } from "../utils/productUtils";
 import axios from "axios";
 import toast from "react-hot-toast";
 import Layout from "./../components/Layout";
 import { AiOutlineReload } from "react-icons/ai";
 import "../styles/Homepages.css";
-
 
 const HomePage = () => {
   const navigate = useNavigate();
@@ -31,7 +30,7 @@ const HomePage = () => {
       }
     } catch (error) {
       console.error(error);
-      toast.error("Error getting categories, please try again later")
+      toast.error("Error getting categories, please try again later");
     }
   };
 
@@ -48,7 +47,7 @@ const HomePage = () => {
       setLoading(false);
     } catch (err) {
       console.error(err);
-      toast.error("Error getting products, please try again later")
+      toast.error("Error getting products, please try again later");
       setLoading(false);
     }
   };
@@ -62,7 +61,7 @@ const HomePage = () => {
       setProducts(data?.products || []);
     } catch (err) {
       console.error(err);
-      toast.error("Error filtering products, please try again later")
+      toast.error("Error filtering products, please try again later");
     }
   };
 
@@ -73,7 +72,7 @@ const HomePage = () => {
       setTotal(data?.total);
     } catch (error) {
       console.error(error);
-      toast.error("Error fetching product count, please try again later")
+      toast.error("Error fetching product count, please try again later");
     }
   };
 
@@ -91,7 +90,7 @@ const HomePage = () => {
       setProducts([...products, ...data?.products]);
     } catch (error) {
       console.error(error);
-      toast.error("Error loading more products, please try again later")
+      toast.error("Error loading more products, please try again later");
       setLoading(false);
     }
   };
@@ -174,7 +173,9 @@ const HomePage = () => {
                 />
                 <div className="card-body">
                   <div className="card-name-price">
-                    <h5 className="card-title" data-testid="product-name">{p.name}</h5>
+                    <h5 className="card-title" data-testid="product-name">
+                      {p.name}
+                    </h5>
                     <h5 className="card-title card-price">
                       {p.price.toLocaleString("en-US", {
                         style: "currency",
@@ -183,7 +184,7 @@ const HomePage = () => {
                     </h5>
                   </div>
                   <p className="card-text ">
-                    {p.description.length < 60 ? p.description : p.description.substring(0, 60)  + "..."}
+                    {truncateDescription60(p.description)}
                   </p>
                   <div className="card-name-price">
                     <button

--- a/client/src/pages/ProductDetails.js
+++ b/client/src/pages/ProductDetails.js
@@ -9,6 +9,7 @@ import {
   getImageUrl,
   addToCart,
   handleImgError,
+  truncateDescription60,
 } from "../utils/productUtils";
 
 const ProductDetails = () => {
@@ -154,9 +155,7 @@ const ProductDetails = () => {
                   </h5>
                 </div>
                 <p className="card-text">
-                  {p.description.length < 60
-                    ? p.description
-                    : p.description.substring(0, 60) + "..."}
+                  {truncateDescription60(p.description)}
                 </p>
                 <div className="card-name-price">
                   <button

--- a/client/src/pages/Search.js
+++ b/client/src/pages/Search.js
@@ -1,6 +1,7 @@
 import React from "react";
 import Layout from "./../components/Layout";
 import { useSearch } from "../context/search";
+import { truncateDescription30 } from "../utils/productUtils";
 const Search = () => {
   const [values, setValues] = useSearch();
   return (
@@ -15,7 +16,7 @@ const Search = () => {
           </h6>
           <div className="d-flex flex-wrap mt-4">
             {values?.results.map((p) => (
-              <div  key={p._id} className="card m-2" style={{ width: "18rem" }}>
+              <div key={p._id} className="card m-2" style={{ width: "18rem" }}>
                 <img
                   src={`/api/v1/product/product-photo/${p._id}`}
                   className="card-img-top"
@@ -24,11 +25,13 @@ const Search = () => {
                 <div className="card-body">
                   <h5 className="card-title">{p.name}</h5>
                   <p className="card-text">
-                    {p.description.substring(0, 30)}...
+                    {truncateDescription30(p.description)}
                   </p>
                   <p className="card-text"> $ {p.price}</p>
                   <button className="btn btn-primary ms-1">More Details</button>
-                  <button className="btn btn-secondary ms-1">ADD TO CART</button>
+                  <button className="btn btn-secondary ms-1">
+                    ADD TO CART
+                  </button>
                 </div>
               </div>
             ))}

--- a/client/src/pages/admin/AdminOrders.js
+++ b/client/src/pages/admin/AdminOrders.js
@@ -6,6 +6,7 @@ import Layout from "../../components/Layout";
 import { useAuth } from "../../context/auth";
 import moment from "moment";
 import { Select } from "antd";
+import { truncateDescription30 } from "../../utils/productUtils";
 const { Option } = Select;
 
 const AdminOrders = () => {
@@ -102,11 +103,7 @@ const AdminOrders = () => {
                       </div>
                       <div className="col-md-8">
                         <p>{p.name}</p>
-                        <p>
-                          {p.description.length <= 30
-                            ? p.description
-                            : p.description.substring(0, 30) + "..."}
-                        </p>
+                        <p>{truncateDescription30(p.description)}</p>
                         <p>Price : {p.price}</p>
                       </div>
                     </div>

--- a/client/src/pages/user/Orders.js
+++ b/client/src/pages/user/Orders.js
@@ -5,6 +5,7 @@ import axios from "axios";
 import toast from "react-hot-toast";
 import { useAuth } from "../../context/auth";
 import moment from "moment";
+import { truncateDescription30 } from "../../utils/productUtils";
 
 const Orders = () => {
   const [orders, setOrders] = useState([]);
@@ -22,10 +23,12 @@ const Orders = () => {
     if (auth?.token) {
       getOrders();
     } else {
-      toast.error("Unable to retrieve Orders, please sign out and sign in again.")
+      toast.error(
+        "Unable to retrieve Orders, please sign out and sign in again."
+      );
     }
   }, [auth]);
-  
+
   return (
     <Layout title={"Your Orders"}>
       <div className="container-flui p-3 m-3 dashboard">
@@ -53,10 +56,18 @@ const Orders = () => {
                       <tr>
                         <td data-testid={"order_index"}>{i + 1}</td>
                         <td data-testid={"order_status"}>{o?.status}</td>
-                        <td data-testid={"order_buyer_name"}>{o?.buyer?.name}</td>
-                        <td data-testid={"order_time"}>{moment(o?.createdAt).fromNow()}</td>
-                        <td data-testid={"order_payment_success"}>{o?.payment.success ? "Success" : "Failed"}</td>
-                        <td data-testid={"order_product_length"}>{o?.products?.length}</td>
+                        <td data-testid={"order_buyer_name"}>
+                          {o?.buyer?.name}
+                        </td>
+                        <td data-testid={"order_time"}>
+                          {moment(o?.createdAt).fromNow()}
+                        </td>
+                        <td data-testid={"order_payment_success"}>
+                          {o?.payment.success ? "Success" : "Failed"}
+                        </td>
+                        <td data-testid={"order_product_length"}>
+                          {o?.products?.length}
+                        </td>
                       </tr>
                     </tbody>
                   </table>
@@ -73,7 +84,7 @@ const Orders = () => {
                         </div>
                         <div className="col-md-8">
                           <p>{p.name}</p>
-                          <p>{p.description.length < 30 ? p.description : p.description.substring(0, 30) + "..."}</p>
+                          <p>{truncateDescription30(p.description)}</p>
                           <p>Price : ${p.price}</p>
                         </div>
                       </div>

--- a/client/src/pages/user/Orders.test.js
+++ b/client/src/pages/user/Orders.test.js
@@ -109,23 +109,6 @@ const twoOrdersTwoProduct = [
   },
 ];
 
-const longDescriptionOrder = [
-  {
-    status: "Processing",
-    buyer: { name: "Bob" },
-    createdAt: "2024-01-01T00:00:00Z",
-    payment: { success: true },
-    products: [
-      {
-        _id: "p2",
-        name: "Mouse",
-        description: "This description is definitely more than thirty characters long for testing.",
-        price: 49,
-      },
-    ],
-  },
-];
-
 // === Tests ===
 describe('Orders Component', () => {
   beforeEach(() => {
@@ -336,45 +319,4 @@ describe('Orders Component', () => {
     });
   });
 
-  it("renders full product description when description length < 30", async () => {
-    axios.get.mockResolvedValueOnce({
-      data: oneOrder,
-    });
-
-    render(
-      <MemoryRouter initialEntries={["/dashboard/user/orders"]}>
-        <Routes>
-          <Route path="/dashboard/user/orders" element={<Orders />} />
-        </Routes>
-      </MemoryRouter>
-    );
-
-    await waitFor(() => expect(axios.get).toHaveBeenCalled());
-
-    await waitFor(() => {
-      expect(screen.getByText(oneOrder[0].products[0].description)).toBeInTheDocument();
-      expect(screen.queryByText(`${oneOrder[0].products[0].description}...`)).not.toBeInTheDocument();
-    });
-  });
-
-  it("renders truncated description with ellipsis when description length ≥ 30", async () => {
-    axios.get.mockResolvedValueOnce({
-      data: longDescriptionOrder,
-    });
-
-    render(
-      <MemoryRouter initialEntries={["/dashboard/user/orders"]}>
-        <Routes>
-          <Route path="/dashboard/user/orders" element={<Orders />} />
-        </Routes>
-      </MemoryRouter>
-    );
-
-    await waitFor(() => expect(axios.get).toHaveBeenCalled());
-
-    await waitFor(() => {
-      const expectedText = longDescriptionOrder[0].products[0].description.substring(0, 30) + "...";
-      expect(screen.getByText(expectedText)).toBeInTheDocument();
-    });
-  });
 });

--- a/client/src/utils/productUtils.js
+++ b/client/src/utils/productUtils.js
@@ -28,3 +28,17 @@ export const addToCart = (cart, setCart, p) => {
 export const handleImgError = (e) => {
   e.target.src = "/images/placeholder.png";
 };
+
+const truncateWithEllipsis = (description = "", limit) => {
+  if (typeof description !== "string") return "";
+  if (description.length <= limit) {
+    return description;
+  }
+  return `${description.substring(0, limit)}...`;
+};
+
+export const truncateDescription30 = (description) =>
+  truncateWithEllipsis(description, 30);
+
+export const truncateDescription60 = (description) =>
+  truncateWithEllipsis(description, 60);

--- a/client/src/utils/productUtils.test.js
+++ b/client/src/utils/productUtils.test.js
@@ -3,6 +3,8 @@ import {
   getImageUrl,
   addToCart,
   handleImgError,
+  truncateDescription30,
+  truncateDescription60,
 } from "./productUtils";
 import toast from "react-hot-toast";
 
@@ -80,5 +82,83 @@ describe("handleImgError", () => {
     const mockEvent = { target: { src: "bad.jpg" } };
     handleImgError(mockEvent);
     expect(mockEvent.target.src).toBe("/images/placeholder.png");
+  });
+});
+
+describe("truncateDescription helpers", () => {
+  describe("truncateDescription30 (limit = 30)", () => {
+    it("should return input unchanged for 29 characters (no ellipsis)", () => {
+      const input = "a".repeat(29);
+
+      const result = truncateDescription30(input);
+
+      expect(result).toBe(input);
+      expect(result.endsWith("...")).toBe(false);
+    });
+
+    it("should return input unchanged for exactly 30 characters (no ellipsis)", () => {
+      const input = "a".repeat(30);
+
+      const result = truncateDescription30(input);
+
+      expect(result).toBe(input);
+      expect(result.endsWith("...")).toBe(false);
+    });
+
+    it("should append ellipsis and keep first 30 chars for 31 characters", () => {
+      const input = "a".repeat(31);
+      const expected = "a".repeat(30) + "...";
+
+      const result = truncateDescription30(input);
+
+      expect(result).toBe(expected);
+    });
+
+    it("should return empty string unchanged for empty input", () => {
+      const input = "";
+
+      const result = truncateDescription30(input);
+
+      expect(result).toBe(input);
+      expect(result.endsWith("...")).toBe(false);
+    });
+  });
+
+  describe("truncateDescription60 (limit = 60)", () => {
+    it("should return input unchanged for 59 characters (no ellipsis)", () => {
+      const input = "a".repeat(59);
+
+      const result = truncateDescription60(input);
+
+      expect(result).toBe(input);
+      expect(result.endsWith("...")).toBe(false);
+    });
+
+    it("should return input unchanged for exactly 60 characters (no ellipsis)", () => {
+      const input = "a".repeat(60);
+
+      const result = truncateDescription60(input);
+
+      expect(result).toBe(input);
+      expect(result.endsWith("...")).toBe(false);
+    });
+
+    it("should append ellipsis and keep first 60 chars for 61 characters", () => {
+      const input = "a".repeat(61);
+      const expected = "a".repeat(60) + "...";
+
+      const result = truncateDescription60(input);
+
+      expect(result).toBe(expected);
+    });
+
+    it("should return empty string unchanged for empty input", () => {
+      const input = "";
+
+      const result = truncateDescription60(input);
+
+      expect(result).toBe(input);
+      expect(result.endsWith("...")).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
Truncating of description is used quite widely across various pages related to products, and there were discrepancies / bug in the way a description was truncated. 

More specifically: 
`{p.description.length < 60 ? p.description : p.description.substring(0, 60) + "..."}`
is wrong because description of length 60 should **not** show the ellipsis

I have extracted all such instances and created helper functions in `productUtils.js` and added unit test for those functions using BVA.
Previously existing test cases have also been removed
